### PR TITLE
Fix StudyTrackerParserTest parseCommand_Edit

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -309,7 +309,7 @@ public class EditCommand extends Command {
          * if modification is attempted.
          * Returns {@code Optional#empty()} if {@code addedAmenities} is null.
          */
-        public Optional<Set<Amenity>> getAmenitiesAdded() {
+        public Optional<Set<Amenity>> getAddedAmenities() {
             return (addedAmenities != null)
                     ? Optional.of(Collections.unmodifiableSet(addedAmenities)) : Optional.empty();
         }
@@ -319,7 +319,7 @@ public class EditCommand extends Command {
          * if modification is attempted.
          * Returns {@code Optional#empty()} if {@code amenities} is null.
          */
-        public Optional<Set<Amenity>> getAmenitiesRemoved() {
+        public Optional<Set<Amenity>> getRemovedAmenities() {
             return (removedAmenities != null)
                     ? Optional.of(Collections.unmodifiableSet(removedAmenities)) : Optional.empty();
         }
@@ -554,8 +554,8 @@ public class EditCommand extends Command {
                     && getAddedTags().equals(e.getAddedTags())
                     && getRemovedTags().equals(e.getRemovedTags())
                     && getAmenities().equals(e.getAmenities())
-                    && getAmenitiesAdded().equals(e.getAmenitiesAdded())
-                    && getAmenitiesRemoved().equals(e.getAmenitiesRemoved());
+                    && getAddedAmenities().equals(e.getAddedAmenities())
+                    && getRemovedAmenities().equals(e.getRemovedAmenities());
         }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/StudyTrackerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StudyTrackerParserTest.java
@@ -54,14 +54,14 @@ public class StudyTrackerParserTest {
         assertEquals(new DeleteCommand(INDEX_FIRST_SPOT), command);
     }
 
-        @Test
-        public void parseCommand_edit() throws Exception {
-            StudySpot studySpot = new StudySpotBuilder().withName("Test").build();
-            EditStudySpotDescriptor descriptor = new EditStudySpotDescriptorBuilder(studySpot).build();
-            EditCommand commandFromParse = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                    + "spot/Test" + " " + StudySpotUtil.getEditStudySpotDescriptorDetails(descriptor));
-            assertEquals(new EditCommand(new Name("Test"), descriptor), commandFromParse);
-        }
+    @Test
+    public void parseCommand_edit() throws Exception {
+        StudySpot studySpot = new StudySpotBuilder().withName("Test").build();
+        EditStudySpotDescriptor descriptor = new EditStudySpotDescriptorBuilder(studySpot).build();
+        EditCommand commandFromParse = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+                + "spot/Test" + " " + StudySpotUtil.getEditStudySpotDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(new Name("Test"), descriptor), commandFromParse);
+    }
 
     @Test
     public void parseCommand_exit() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/StudyTrackerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StudyTrackerParserTest.java
@@ -16,13 +16,17 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditCommand.EditStudySpotDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.NameContainsKeywordsPredicate;
 import seedu.address.model.studyspot.StudySpot;
+import seedu.address.testutil.EditStudySpotDescriptorBuilder;
 import seedu.address.testutil.StudySpotBuilder;
 import seedu.address.testutil.StudySpotUtil;
 
@@ -50,16 +54,14 @@ public class StudyTrackerParserTest {
         assertEquals(new DeleteCommand(INDEX_FIRST_SPOT), command);
     }
 
-    //    @Test
-    //    public void parseCommand_edit() throws Exception {
-    //        StudySpot studySpot = new StudySpotBuilder().withName("Test").build();
-    //        EditCommand.EditStudySpotDescriptor descriptor = new EditStudySpotDescriptorBuilder(studySpot).build();
-    //        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-    //                + "spot/Test" + " " + StudySpotUtil.getEditStudySpotDescriptorDetails(descriptor));
-    //        boolean a = (new EditCommand(new Name("Test"), descriptor)).equals(command);
-    //        assertEquals(new EditCommand(new Name("Test"), descriptor), command);
-    //        //todo discrepancies in amenities and addedamenities
-    //    }
+        @Test
+        public void parseCommand_edit() throws Exception {
+            StudySpot studySpot = new StudySpotBuilder().withName("Test").build();
+            EditStudySpotDescriptor descriptor = new EditStudySpotDescriptorBuilder(studySpot).build();
+            EditCommand commandFromParse = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+                    + "spot/Test" + " " + StudySpotUtil.getEditStudySpotDescriptorDetails(descriptor));
+            assertEquals(new EditCommand(new Name("Test"), descriptor), commandFromParse);
+        }
 
     @Test
     public void parseCommand_exit() throws Exception {

--- a/src/test/java/seedu/address/testutil/EditStudySpotDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditStudySpotDescriptorBuilder.java
@@ -37,8 +37,8 @@ public class EditStudySpotDescriptorBuilder {
         descriptor.setRating(studySpot.getRating());
         descriptor.setEmail(studySpot.getEmail());
         descriptor.setAddress(studySpot.getAddress());
-        descriptor.setTags(studySpot.getTags());
-        descriptor.setAmenities(studySpot.getAmenities());
+        descriptor.setAddedTags(studySpot.getTags());
+        descriptor.setAddedAmenities(studySpot.getAmenities());
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/StudySpotUtil.java
+++ b/src/test/java/seedu/address/testutil/StudySpotUtil.java
@@ -53,20 +53,20 @@ public class StudySpotUtil {
         descriptor.getRating().ifPresent(rating -> sb.append(PREFIX_RATING).append(rating.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
-        if (descriptor.getTags().isPresent()) {
-            Set<Tag> tags = descriptor.getTags().get();
-            if (tags.isEmpty()) {
+        if (descriptor.getAddedTags().isPresent()) {
+            if (descriptor.getAddedTags().get().isEmpty()) {
                 sb.append(PREFIX_TAG);
             } else {
+                Set<Tag> tags = descriptor.getAddedTags().get();
                 tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
             }
         }
         sb.append(" ");
-        if (descriptor.getAmenities().isPresent()) {
-            Set<Amenity> amenities = descriptor.getAmenities().get();
-            if (amenities.isEmpty()) {
+        if (descriptor.getAddedAmenities().isPresent()) {
+            if (descriptor.getAddedAmenities().get().isEmpty()) {
                 sb.append(PREFIX_AMENITY);
             } else {
+                Set<Amenity> amenities = descriptor.getAddedAmenities().get();
                 amenities.forEach(s -> sb.append(PREFIX_AMENITY).append(s.amenityType).append(" "));
             }
         }


### PR DESCRIPTION
Issue:

`StudySpot studySpot = new StudySpotBuilder().withName("Test").build();`
Creates a `studySpot` with Amenities as Set with 0 elements, tags as 0 elements

`EditCommand.EditStudySpotDescriptor descriptor = new EditStudySpotDescriptorBuilder(studySpot).build();`
Creates a descriptor based off this `studySpot`, also setting Amenity as a Set with 0 elements, tags as 0 elements

`EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                   + "spot/Test" + " " + StudySpotUtil.getEditStudySpotDescriptorDetails(descriptor));`
 In this `parseCommand`, a descriptor is built according to the given command. Since descriptor contains an empty set of
 amenity and tags, it includes "t/ m/" in the created string.
 
 As a result, because of the way how `EditCommandParser` works, it will create a `EditStudySpotDescriptor` with `addedAmenity` set of 0 (because it takes from amenity), and `addedTag` set of 0 (because it takes from tag).

The difference is apparent, as the descriptor created with the studySpot has an empty amenity set and an empty tag set, while addedAmenity and addedTags are null, while the descriptor created based off the parse has an empty addedAmenity and addedTags set, while tags and amenities are null.
 
 To fix this, I changed it such that EditStudySpotDescriptorBuilder will set addedAmenity as a set of 0, addedTags as a set of 0 rather than tags and amenity, since in Edit we should not be using tag or amenity, rather use addedTag and addedAmenity