### PR TITLE
Implement Add favourites

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,5 +9,5 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_STUDYSPOT_DISPLAYED_INDEX = "The study spot index provided is invalid";
     public static final String MESSAGE_STUDYSPOT_LISTED_OVERVIEW = "%1$d study spot(s) listed!";
-    public static final String MESSAGE_INVALID_EDIT_NAME = "The name provided was not found!";
+    public static final String MESSAGE_NAME_NOT_FOUND = "The name provided was not found!";
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,13 +10,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_AMENITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDYSPOTS;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -24,6 +22,7 @@ import seedu.address.model.Model;
 import seedu.address.model.amenity.Amenity;
 import seedu.address.model.studyspot.Address;
 import seedu.address.model.studyspot.Email;
+import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.Rating;
 import seedu.address.model.studyspot.StudySpot;
@@ -65,7 +64,7 @@ public class EditCommand extends Command {
     public static final String FIELD_TAG = "tag";
     public static final String FIELD_AMENITY = "amenity";
 
-    private Name name;
+    private final Name name;
     private final EditStudySpotDescriptor editStudySpotDescriptor;
 
     /**
@@ -127,8 +126,10 @@ public class EditCommand extends Command {
                 .getTags().orElse(studySpotToEdit.getTags());
         Set<Amenity> updatedAmenities = editStudySpotDescriptor.updateAmenities(studySpotToEdit.getAmenities())
                 .getAmenities().orElse(studySpotToEdit.getAmenities());
+        Favourite updatedFavourite = editStudySpotDescriptor.getFavourite().orElse(studySpotToEdit.getFavourite());
 
-        return new StudySpot(updatedName, updatedRating, updatedEmail, updatedAddress, updatedTags, updatedAmenities);
+        return new StudySpot(updatedName, updatedRating, updatedEmail, updatedAddress, updatedFavourite,
+                updatedTags, updatedAmenities);
     }
 
     @Override
@@ -158,6 +159,7 @@ public class EditCommand extends Command {
         private Rating rating;
         private Email email;
         private Address address;
+        private Favourite favourite;
         private Set<Tag> tags;
         private Set<Tag> addedTags;
         private Set<Tag> removedTags;
@@ -176,6 +178,7 @@ public class EditCommand extends Command {
             setRating(toCopy.rating);
             setEmail(toCopy.email);
             setAddress(toCopy.address);
+            setFavourite(toCopy.favourite);
             setTags(toCopy.tags);
             setAddedTags(toCopy.addedTags);
             setRemovedTags(toCopy.removedTags);
@@ -222,6 +225,14 @@ public class EditCommand extends Command {
 
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
+        }
+
+        public void setFavourite(Favourite favourite) {
+            this.favourite = favourite;
+        }
+
+        public Optional<Favourite> getFavourite() {
+            return Optional.ofNullable(favourite);
         }
 
         /**
@@ -557,5 +568,6 @@ public class EditCommand extends Command {
                     && getAmenitiesAdded().equals(e.getAmenitiesAdded())
                     && getAmenitiesRemoved().equals(e.getAmenitiesRemoved());
         }
+
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,11 +10,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_AMENITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDYSPOTS;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -563,6 +563,7 @@ public class EditCommand extends Command {
                     && getRating().equals(e.getRating())
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())
+                    && getFavourite().equals(e.getFavourite())
                     && getTags().equals(e.getTags())
                     && getAddedTags().equals(e.getAddedTags())
                     && getRemovedTags().equals(e.getRemovedTags())

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -96,7 +96,7 @@ public class EditCommand extends Command {
         }
 
         if (!isPresent) {
-            throw new CommandException(Messages.MESSAGE_INVALID_EDIT_NAME);
+            throw new CommandException(Messages.MESSAGE_NAME_NOT_FOUND);
         }
 
         StudySpot editedStudySpot = createEditedStudySpot(studySpotToEdit, editStudySpotDescriptor);

--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import java.util.List;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.StudySpot;
 
@@ -48,7 +49,11 @@ public class FavouriteCommand extends Command {
             throw new CommandException(MESSAGE_NAME_NOT_FOUND);
         }
 
-        model.addStudySpotToFavourites(studySpotToFavourite);
+        StudySpot favouriteStudySpot = new StudySpot(studySpotToFavourite.getName(), studySpotToFavourite.getRating(),
+                studySpotToFavourite.getEmail(), studySpotToFavourite.getAddress(), new Favourite(true),
+                studySpotToFavourite.getTags(), studySpotToFavourite.getAmenities());
+        model.setStudySpot(studySpotToFavourite, favouriteStudySpot);
+        model.addStudySpotToFavourites(favouriteStudySpot);
         return new CommandResult(String.format(MESSAGE_FAVOURITE_STUDYSPOT_SUCCESS, studySpotToFavourite));
     }
 

--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_NAME_NOT_FOUND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EDIT_SPOT;
+import java.util.List;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.studyspot.Name;
+import seedu.address.model.studyspot.StudySpot;
+
+/**
+ * Deletes a study spot identified using it's displayed index from the study tracker.
+ */
+public class FavouriteCommand extends Command {
+
+    public static final String COMMAND_WORD = "fav";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Adds the study spot to favourites.\n"
+            + "Parameters: "
+            + "[" + PREFIX_EDIT_SPOT + "NAME] (non-case sensitive) "
+            + "Example: " + COMMAND_WORD + " " + PREFIX_EDIT_SPOT + "tr3 ";
+
+    public static final String MESSAGE_FAVOURITE_STUDYSPOT_SUCCESS = "Added study spot to favourites: %1$s";
+
+    private final Name name;
+
+    public FavouriteCommand(Name name) {
+        this.name = name;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<StudySpot> lastShownList = model.getFullList();
+
+        boolean isPresent = false;
+        StudySpot studySpotToFavourite = null;
+        for (StudySpot current: lastShownList) {
+            if (current.isSameName(name)) {
+                studySpotToFavourite = current;
+                isPresent = true;
+                break;
+            }
+        }
+        if (!model.hasStudySpot(studySpotToFavourite)) {
+            throw new CommandException(MESSAGE_NAME_NOT_FOUND);
+        }
+
+        model.addStudySpotToFavourites(studySpotToFavourite);
+        return new CommandResult(String.format(MESSAGE_FAVOURITE_STUDYSPOT_SUCCESS, studySpotToFavourite));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FavouriteCommand // instanceof handles nulls
+                && name.equals(((FavouriteCommand) other).name)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -3,10 +3,11 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_NAME_NOT_FOUND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
 import java.util.List;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.StudySpot;
 
@@ -24,6 +25,8 @@ public class FavouriteCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "tr3 ";
 
     public static final String MESSAGE_FAVOURITE_STUDYSPOT_SUCCESS = "Added study spot to favourites: %1$s";
+    public static final String MESSAGE_FAVOURITE_REPEATSTUDYSPOT_FAIL =
+            "Study spot provided is already a favourite: %1$s";
 
     private final Name name;
 
@@ -48,13 +51,13 @@ public class FavouriteCommand extends Command {
         if (!isPresent) {
             throw new CommandException(MESSAGE_NAME_NOT_FOUND);
         }
+        if (studySpotToFavourite.isFavourite()) {
+            throw new CommandException(String.format(MESSAGE_FAVOURITE_REPEATSTUDYSPOT_FAIL,
+                    studySpotToFavourite.getName()));
+        }
 
-        StudySpot favouriteStudySpot = new StudySpot(studySpotToFavourite.getName(), studySpotToFavourite.getRating(),
-                studySpotToFavourite.getEmail(), studySpotToFavourite.getAddress(), new Favourite(true),
-                studySpotToFavourite.getTags(), studySpotToFavourite.getAmenities());
-        model.setStudySpot(studySpotToFavourite, favouriteStudySpot);
-        model.addStudySpotToFavourites(favouriteStudySpot);
-        return new CommandResult(String.format(MESSAGE_FAVOURITE_STUDYSPOT_SUCCESS, studySpotToFavourite));
+        StudySpot updatedStudySpot = model.addStudySpotToFavourites(studySpotToFavourite);
+        return new CommandResult(String.format(MESSAGE_FAVOURITE_STUDYSPOT_SUCCESS, updatedStudySpot.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -44,7 +44,7 @@ public class FavouriteCommand extends Command {
                 break;
             }
         }
-        if (!model.hasStudySpot(studySpotToFavourite)) {
+        if (!isPresent) {
             throw new CommandException(MESSAGE_NAME_NOT_FOUND);
         }
 

--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_NAME_NOT_FOUND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EDIT_SPOT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import java.util.List;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -19,8 +19,8 @@ public class FavouriteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds the study spot to favourites.\n"
             + "Parameters: "
-            + "[" + PREFIX_EDIT_SPOT + "NAME] (non-case sensitive) "
-            + "Example: " + COMMAND_WORD + " " + PREFIX_EDIT_SPOT + "tr3 ";
+            + "[" + PREFIX_NAME + "NAME] (non-case sensitive) "
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "tr3 ";
 
     public static final String MESSAGE_FAVOURITE_STUDYSPOT_SUCCESS = "Added study spot to favourites: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
@@ -3,10 +3,11 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_NAME_NOT_FOUND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
 import java.util.List;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.StudySpot;
 
@@ -24,6 +25,8 @@ public class UnfavouriteCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "tr3 ";
 
     public static final String MESSAGE_UNFAVOURITE_STUDYSPOT_SUCCESS = "Removed study spot from favourites: %1$s";
+    public static final String MESSAGE_UNFAVOURITE_REPEATSTUDYSPOT_FAIL =
+            "Study spot provided is not a favourite: %1$s";
 
     private final Name name;
 
@@ -49,12 +52,13 @@ public class UnfavouriteCommand extends Command {
             throw new CommandException(MESSAGE_NAME_NOT_FOUND);
         }
 
-        StudySpot favouriteStudySpot = new StudySpot(studySpotToUnfavourite.getName(), studySpotToUnfavourite.getRating(),
-                studySpotToUnfavourite.getEmail(), studySpotToUnfavourite.getAddress(), new Favourite(false),
-                studySpotToUnfavourite.getTags(), studySpotToUnfavourite.getAmenities());
-        model.setStudySpot(studySpotToUnfavourite, favouriteStudySpot);
-        model.removeStudySpotFromFavourites(studySpotToUnfavourite);
-        return new CommandResult(String.format(MESSAGE_UNFAVOURITE_STUDYSPOT_SUCCESS, studySpotToUnfavourite));
+        if (!studySpotToUnfavourite.isFavourite()) {
+            throw new CommandException(String.format(MESSAGE_UNFAVOURITE_REPEATSTUDYSPOT_FAIL,
+                    studySpotToUnfavourite.getName()));
+        }
+
+        StudySpot updatedStudySpot = model.removeStudySpotFromFavourites(studySpotToUnfavourite);
+        return new CommandResult(String.format(MESSAGE_UNFAVOURITE_STUDYSPOT_SUCCESS, updatedStudySpot.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_NAME_NOT_FOUND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import java.util.List;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.studyspot.Name;
+import seedu.address.model.studyspot.StudySpot;
+
+/**
+ * Deletes a study spot identified using it's displayed index from the study tracker.
+ */
+public class UnfavouriteCommand extends Command {
+
+    public static final String COMMAND_WORD = "unfav";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Removes the study spot from favourites.\n"
+            + "Parameters: "
+            + "[" + PREFIX_NAME + "NAME] (non-case sensitive) "
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "tr3 ";
+
+    public static final String MESSAGE_UNFAVOURITE_STUDYSPOT_SUCCESS = "Removed study spot from favourites: %1$s";
+
+    private final Name name;
+
+    public UnfavouriteCommand(Name name) {
+        this.name = name;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<StudySpot> lastShownList = model.getFullList();
+
+        boolean isPresent = false;
+        StudySpot studySpotToUnfavourite = null;
+        for (StudySpot current: lastShownList) {
+            if (current.isSameName(name)) {
+                studySpotToUnfavourite = current;
+                isPresent = true;
+                break;
+            }
+        }
+        if (!isPresent) {
+            throw new CommandException(MESSAGE_NAME_NOT_FOUND);
+        }
+
+        model.removeStudySpotFromFavourites(studySpotToUnfavourite);
+        return new CommandResult(String.format(MESSAGE_UNFAVOURITE_STUDYSPOT_SUCCESS, studySpotToUnfavourite));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UnfavouriteCommand // instanceof handles nulls
+                && name.equals(((UnfavouriteCommand) other).name)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import java.util.List;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.StudySpot;
 
@@ -48,6 +49,10 @@ public class UnfavouriteCommand extends Command {
             throw new CommandException(MESSAGE_NAME_NOT_FOUND);
         }
 
+        StudySpot favouriteStudySpot = new StudySpot(studySpotToUnfavourite.getName(), studySpotToUnfavourite.getRating(),
+                studySpotToUnfavourite.getEmail(), studySpotToUnfavourite.getAddress(), new Favourite(false),
+                studySpotToUnfavourite.getTags(), studySpotToUnfavourite.getAmenities());
+        model.setStudySpot(studySpotToUnfavourite, favouriteStudySpot);
         model.removeStudySpotFromFavourites(studySpotToUnfavourite);
         return new CommandResult(String.format(MESSAGE_UNFAVOURITE_STUDYSPOT_SUCCESS, studySpotToUnfavourite));
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -7,16 +7,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
 import java.util.Set;
 import java.util.stream.Stream;
-
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.amenity.Amenity;
 import seedu.address.model.studyspot.Address;
 import seedu.address.model.studyspot.Email;
-import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.Rating;
 import seedu.address.model.studyspot.StudySpot;

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -7,8 +7,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
 import java.util.Set;
 import java.util.stream.Stream;
+
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.amenity.Amenity;

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.amenity.Amenity;
 import seedu.address.model.studyspot.Address;
 import seedu.address.model.studyspot.Email;
+import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.Rating;
 import seedu.address.model.studyspot.StudySpot;

--- a/src/main/java/seedu/address/logic/parser/FavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FavouriteCommandParser.java
@@ -1,7 +1,10 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.NoSuchElementException;
 
 import seedu.address.logic.commands.FavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -20,7 +23,12 @@ public class FavouriteCommandParser implements Parser<FavouriteCommand> {
     public FavouriteCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Name name;
+        try {
+            name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        } catch (NoSuchElementException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavouriteCommand.MESSAGE_USAGE), pe);
+        }
         return new FavouriteCommand(name);
     }
 

--- a/src/main/java/seedu/address/logic/parser/FavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FavouriteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
 import seedu.address.logic.commands.FavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.studyspot.Name;

--- a/src/main/java/seedu/address/logic/parser/FavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FavouriteCommandParser.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import seedu.address.logic.commands.FavouriteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.studyspot.Name;
+
+/**
+ * Parses input arguments and creates a new FavouriteCommand object
+ */
+public class FavouriteCommandParser implements Parser<FavouriteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FavouriteCommand
+     * and returns a FavouriteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FavouriteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        return new FavouriteCommand(name);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/StudyTrackerParser.java
+++ b/src/main/java/seedu/address/logic/parser/StudyTrackerParser.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;

--- a/src/main/java/seedu/address/logic/parser/StudyTrackerParser.java
+++ b/src/main/java/seedu/address/logic/parser/StudyTrackerParser.java
@@ -2,16 +2,15 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FavouriteCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -52,6 +51,9 @@ public class StudyTrackerParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case FavouriteCommand.COMMAND_WORD:
+            return new FavouriteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/StudyTrackerParser.java
+++ b/src/main/java/seedu/address/logic/parser/StudyTrackerParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.FavouriteCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UnfavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -54,6 +55,9 @@ public class StudyTrackerParser {
 
         case FavouriteCommand.COMMAND_WORD:
             return new FavouriteCommandParser().parse(arguments);
+
+        case UnfavouriteCommand.COMMAND_WORD:
+            return new UnfavouriteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/UnfavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnfavouriteCommandParser.java
@@ -27,7 +27,8 @@ public class UnfavouriteCommandParser implements Parser<UnfavouriteCommand> {
         try {
             name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         } catch (NoSuchElementException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnfavouriteCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnfavouriteCommand.MESSAGE_USAGE), pe);
         }
         return new UnfavouriteCommand(name);
     }

--- a/src/main/java/seedu/address/logic/parser/UnfavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnfavouriteCommandParser.java
@@ -1,7 +1,10 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.NoSuchElementException;
 
 import seedu.address.logic.commands.UnfavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -20,7 +23,12 @@ public class UnfavouriteCommandParser implements Parser<UnfavouriteCommand> {
     public UnfavouriteCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Name name;
+        try {
+            name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        } catch (NoSuchElementException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnfavouriteCommand.MESSAGE_USAGE), pe);
+        }
         return new UnfavouriteCommand(name);
     }
 

--- a/src/main/java/seedu/address/logic/parser/UnfavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnfavouriteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
 import seedu.address.logic.commands.UnfavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.studyspot.Name;

--- a/src/main/java/seedu/address/logic/parser/UnfavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnfavouriteCommandParser.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import seedu.address.logic.commands.UnfavouriteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.studyspot.Name;
+
+/**
+ * Parses input arguments and creates a new UnfavouriteCommand object
+ */
+public class UnfavouriteCommandParser implements Parser<UnfavouriteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnfavouriteCommand
+     * and returns a UnfavouriteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnfavouriteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        return new UnfavouriteCommand(name);
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -78,6 +78,11 @@ public interface Model {
     void setStudySpot(StudySpot target, StudySpot editedStudySpot);
 
     /**
+     * Returns true if a study spot with the same identity as {@code studySpot} is a favourite in the study tracker.
+     */
+    public boolean isFavouriteStudySpot(StudySpot studySpot);
+
+    /**
      * Adds the given study spot to favourites.
      * {@code study spot} must already exist in the study tracker.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -85,15 +85,19 @@ public interface Model {
     /**
      * Adds the given study spot to favourites.
      * {@code study spot} must already exist in the study tracker.
+     *
+     * @return Returns updated study spot.
      */
-    void addStudySpotToFavourites(StudySpot studySpot);
+    StudySpot addStudySpotToFavourites(StudySpot studySpot);
 
 
     /**
      * Removes the given study spot from favourites.
      * {@code study spot} must already exist in the study tracker.
+     *
+     * @return Returns updated study spot.
      */
-    void removeStudySpotFromFavourites(StudySpot studySpot);
+    StudySpot removeStudySpotFromFavourites(StudySpot studySpot);
 
     /** Returns an unmodifiable view of the filtered study spot list */
     ObservableList<StudySpot> getFilteredStudySpotList();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -77,6 +77,19 @@ public interface Model {
      */
     void setStudySpot(StudySpot target, StudySpot editedStudySpot);
 
+    /**
+     * Adds the given study spot to favourites.
+     * {@code study spot} must already exist in the study tracker.
+     */
+    void addStudySpotToFavourites(StudySpot studySpot);
+
+
+    /**
+     * Removes the given study spot from favourites.
+     * {@code study spot} must already exist in the study tracker.
+     */
+    void removeStudySpotFromFavourites(StudySpot studySpot);
+
     /** Returns an unmodifiable view of the filtered study spot list */
     ObservableList<StudySpot> getFilteredStudySpotList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -102,6 +102,9 @@ public class ModelManager implements Model {
     @Override
     public void addStudySpot(StudySpot studySpot) {
         studyTracker.addStudySpot(studySpot);
+        if (studySpot.isFavourite()) {
+            addStudySpotToFavourites(studySpot);
+        }
         updateFilteredStudySpotList(PREDICATE_SHOW_ALL_STUDYSPOTS);
     }
 
@@ -129,8 +132,9 @@ public class ModelManager implements Model {
      * @param studySpot
      */
     @Override
-    public void addStudySpotToFavourites(StudySpot studySpot) {
-        studyTracker.addStudySpotToFavourites(studySpot);
+    public StudySpot addStudySpotToFavourites(StudySpot studySpot) {
+        StudySpot favStudySpot = studyTracker.addStudySpotToFavourites(studySpot);
+        return favStudySpot;
     }
 
     /**
@@ -140,8 +144,9 @@ public class ModelManager implements Model {
      * @param studySpot
      */
     @Override
-    public void removeStudySpotFromFavourites(StudySpot studySpot) {
-        studyTracker.removeStudySpotFromFavourites(studySpot);
+    public StudySpot removeStudySpotFromFavourites(StudySpot studySpot) {
+        StudySpot unfavStudySpot = studyTracker.removeStudySpotFromFavourites(studySpot);
+        return unfavStudySpot;
     }
 
     //=========== Filtered StudySpot List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -112,6 +112,28 @@ public class ModelManager implements Model {
         studyTracker.setStudySpot(target, editedStudySpot);
     }
 
+    /**
+     * Adds the given study spot to favourites.
+     * {@code study spot} must already exist in the study tracker.
+     *
+     * @param studySpot
+     */
+    @Override
+    public void addStudySpotToFavourites(StudySpot studySpot) {
+
+    }
+
+    /**
+     * Removes the given study spot from favourites.
+     * {@code study spot} must already exist in the study tracker.
+     *
+     * @param studySpot
+     */
+    @Override
+    public void removeStudySpotFromFavourites(StudySpot studySpot) {
+
+    }
+
     //=========== Filtered StudySpot List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -113,6 +113,16 @@ public class ModelManager implements Model {
     }
 
     /**
+     * Returns true if a study spot with the same identity as {@code studySpot} is a favourite in the study tracker.
+     *
+     * @param studySpot
+     */
+    @Override
+    public boolean isFavouriteStudySpot(StudySpot studySpot) {
+        return studyTracker.isFavouriteStudySpot(studySpot);
+    }
+
+    /**
      * Adds the given study spot to favourites.
      * {@code study spot} must already exist in the study tracker.
      *
@@ -120,7 +130,7 @@ public class ModelManager implements Model {
      */
     @Override
     public void addStudySpotToFavourites(StudySpot studySpot) {
-
+        studyTracker.addStudySpotToFavourites(studySpot);
     }
 
     /**
@@ -131,7 +141,7 @@ public class ModelManager implements Model {
      */
     @Override
     public void removeStudySpotFromFavourites(StudySpot studySpot) {
-
+        studyTracker.removeStudySpotFromFavourites(studySpot);
     }
 
     //=========== Filtered StudySpot List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ReadOnlyStudyTracker.java
+++ b/src/main/java/seedu/address/model/ReadOnlyStudyTracker.java
@@ -14,4 +14,9 @@ public interface ReadOnlyStudyTracker {
      */
     ObservableList<StudySpot> getStudySpotList();
 
+    /**
+     * Returns an unmodifiable view of the favourite study spots list.
+     * This list will not contain any duplicate study spots.
+     */
+    ObservableList<StudySpot> getFavouriteStudySpotList();
 }

--- a/src/main/java/seedu/address/model/StudyTracker.java
+++ b/src/main/java/seedu/address/model/StudyTracker.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.StudySpot;
 import seedu.address.model.studyspot.UniqueStudySpotList;
 
@@ -120,9 +121,16 @@ public class StudyTracker implements ReadOnlyStudyTracker {
      * {@code study spot} must already exist in the study tracker.
      *
      * @param studySpot
+     * @return Returns the updated study spot.
      */
-    public void addStudySpotToFavourites(StudySpot studySpot) {
-        favouriteStudySpots.add(studySpot);
+    public StudySpot addStudySpotToFavourites(StudySpot studySpot) {
+        assert(hasStudySpot(studySpot) == true);
+        StudySpot favouriteStudySpot = new StudySpot(studySpot.getName(), studySpot.getRating(),
+                studySpot.getEmail(), studySpot.getAddress(), new Favourite(true),
+                studySpot.getTags(), studySpot.getAmenities());
+        setStudySpot(studySpot, favouriteStudySpot);
+        favouriteStudySpots.add(favouriteStudySpot);
+        return favouriteStudySpot;
     }
 
     /**
@@ -130,9 +138,16 @@ public class StudyTracker implements ReadOnlyStudyTracker {
      * {@code study spot} must already exist in the study tracker.
      *
      * @param studySpot
+     * @return Returns the updated study spot.
      */
-    public void removeStudySpotFromFavourites(StudySpot studySpot) {
+    public StudySpot removeStudySpotFromFavourites(StudySpot studySpot) {
+        assert(hasStudySpot(studySpot) == true);
+        StudySpot unfavouriteStudySpot = new StudySpot(studySpot.getName(), studySpot.getRating(),
+                studySpot.getEmail(), studySpot.getAddress(), new Favourite(false),
+                studySpot.getTags(), studySpot.getAmenities());
+        setStudySpot(studySpot, unfavouriteStudySpot);
         favouriteStudySpots.remove(studySpot);
+        return unfavouriteStudySpot;
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/StudyTracker.java
+++ b/src/main/java/seedu/address/model/StudyTracker.java
@@ -15,6 +15,7 @@ import seedu.address.model.studyspot.UniqueStudySpotList;
 public class StudyTracker implements ReadOnlyStudyTracker {
 
     private final UniqueStudySpotList studySpots;
+    private final UniqueStudySpotList favouriteStudySpots;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -25,6 +26,7 @@ public class StudyTracker implements ReadOnlyStudyTracker {
      */
     {
         studySpots = new UniqueStudySpotList();
+        favouriteStudySpots = new UniqueStudySpotList();
     }
 
     public StudyTracker() {}
@@ -48,12 +50,21 @@ public class StudyTracker implements ReadOnlyStudyTracker {
     }
 
     /**
+     * Replaces the contents of the study spot list with {@code studySpots}.
+     * {@code studySpots} must not contain duplicate study spots.
+     */
+    public void setFavouriteStudySpots(List<StudySpot> studySpots) {
+        this.favouriteStudySpots.setStudySpots(studySpots);
+    }
+
+    /**
      * Resets the existing data of this {@code StudyTracker} with {@code newData}.
      */
     public void resetData(ReadOnlyStudyTracker newData) {
         requireNonNull(newData);
 
         setStudySpots(newData.getStudySpotList());
+        setFavouriteStudySpots(newData.getFavouriteStudySpotList());
     }
 
     //// study spot-level operations
@@ -94,6 +105,36 @@ public class StudyTracker implements ReadOnlyStudyTracker {
         studySpots.remove(key);
     }
 
+    //// Favourite study spot-level operations
+
+    /**
+     * Returns true if a study spot with the same identity as {@code studySpot} is a favourite in the study tracker.
+     */
+    public boolean isFavouriteStudySpot(StudySpot studySpot) {
+        requireNonNull(studySpot);
+        return favouriteStudySpots.contains(studySpot);
+    }
+
+    /**
+     * Adds the given study spot to favourites.
+     * {@code study spot} must already exist in the study tracker.
+     *
+     * @param studySpot
+     */
+    public void addStudySpotToFavourites(StudySpot studySpot) {
+        favouriteStudySpots.add(studySpot);
+    }
+
+    /**
+     * Removes the given study spot from favourites.
+     * {@code study spot} must already exist in the study tracker.
+     *
+     * @param studySpot
+     */
+    public void removeStudySpotFromFavourites(StudySpot studySpot) {
+        favouriteStudySpots.remove(studySpot);
+    }
+
     //// util methods
 
     @Override
@@ -108,14 +149,21 @@ public class StudyTracker implements ReadOnlyStudyTracker {
     }
 
     @Override
+    public ObservableList<StudySpot> getFavouriteStudySpotList() {
+        return favouriteStudySpots.asUnmodifiableObservableList();
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof StudyTracker // instanceof handles nulls
-                && studySpots.equals(((StudyTracker) other).studySpots));
+                && studySpots.equals(((StudyTracker) other).studySpots)
+                && favouriteStudySpots.equals(((StudyTracker) other).favouriteStudySpots));
     }
 
     @Override
     public int hashCode() {
         return studySpots.hashCode();
     }
+
 }

--- a/src/main/java/seedu/address/model/studyspot/Favourite.java
+++ b/src/main/java/seedu/address/model/studyspot/Favourite.java
@@ -1,0 +1,46 @@
+package seedu.address.model.studyspot;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents if a StudySpot is a favourite in the study tracker.
+ * Guarantees: immutable;
+ */
+public class Favourite {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Favourites should only be true or false, and it should not be blank";
+
+    public final boolean isFavourite;
+
+    /**
+     * Constructs a {@code Favourite}.
+     *
+     * @param isFavourite represents if a Study Spot is a favourite.
+     */
+    public Favourite(boolean isFavourite) {
+        requireNonNull(isFavourite);
+        this.isFavourite = isFavourite;
+    }
+
+    /**
+     * Returns boolean that represents if a Study Spot is a favourite.
+     * @return boolean
+     */
+    public boolean isFavourite() {
+        return isFavourite;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(isFavourite);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Favourite // instanceof handles nulls
+                && isFavourite == ((Favourite) other).isFavourite); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/studyspot/Favourite.java
+++ b/src/main/java/seedu/address/model/studyspot/Favourite.java
@@ -9,9 +9,10 @@ import static java.util.Objects.requireNonNull;
 public class Favourite {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Favourites should only be true or false, and it should not be blank";
+            "Favourite should only be true or false, and it should not be blank";
 
     public final boolean isFavourite;
+    public final String value;
 
     /**
      * Constructs a {@code Favourite}.
@@ -21,6 +22,7 @@ public class Favourite {
     public Favourite(boolean isFavourite) {
         requireNonNull(isFavourite);
         this.isFavourite = isFavourite;
+        this.value = String.valueOf(isFavourite);
     }
 
     /**
@@ -31,9 +33,16 @@ public class Favourite {
         return isFavourite;
     }
 
+    /**
+     * Returns true if a given string is a valid favourite.
+     */
+    public static boolean isValidFavourite(String test) {
+        return test.equals("true") || test.equals("false");
+    }
+
     @Override
     public String toString() {
-        return String.valueOf(isFavourite);
+        return value;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/studyspot/StudySpot.java
+++ b/src/main/java/seedu/address/model/studyspot/StudySpot.java
@@ -45,7 +45,8 @@ public class StudySpot {
      * Overloaded constructor with favourite specified.
      * Every field must be present and not null.
      */
-    public StudySpot(Name name, Rating rating, Email email, Address address, Favourite favourite, Set<Tag> tags, Set<Amenity> amenities) {
+    public StudySpot(Name name, Rating rating, Email email, Address address, Favourite favourite,
+                     Set<Tag> tags, Set<Amenity> amenities) {
         requireAllNonNull(name, rating, email, address, tags, amenities);
         this.name = name;
         this.rating = rating;
@@ -128,6 +129,7 @@ public class StudySpot {
                 && otherStudySpot.getRating().equals(getRating())
                 && otherStudySpot.getEmail().equals(getEmail())
                 && otherStudySpot.getAddress().equals(getAddress())
+                && otherStudySpot.getFavourite().equals(getFavourite())
                 && otherStudySpot.getTags().equals(getTags())
                 && otherStudySpot.getAmenities().equals(getAmenities());
     }
@@ -147,7 +149,9 @@ public class StudySpot {
                 .append("; Email: ")
                 .append(getEmail())
                 .append("; Address: ")
-                .append(getAddress());
+                .append(getAddress())
+                .append("; Favourite: ")
+                .append(getFavourite());
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {

--- a/src/main/java/seedu/address/model/studyspot/StudySpot.java
+++ b/src/main/java/seedu/address/model/studyspot/StudySpot.java
@@ -20,6 +20,7 @@ public class StudySpot {
     private final Name name;
     private final Rating rating;
     private final Email email;
+    private final Favourite favourite;
 
     // Data fields
     private final Address address;
@@ -37,6 +38,22 @@ public class StudySpot {
         this.address = address;
         this.tags.addAll(tags);
         this.amenities.addAll(amenities);
+        this.favourite = new Favourite(false);
+    }
+
+    /**
+     * Overloaded constructor with favourite specified.
+     * Every field must be present and not null.
+     */
+    public StudySpot(Name name, Rating rating, Email email, Address address, Favourite favourite, Set<Tag> tags, Set<Amenity> amenities) {
+        requireAllNonNull(name, rating, email, address, tags, amenities);
+        this.name = name;
+        this.rating = rating;
+        this.email = email;
+        this.address = address;
+        this.tags.addAll(tags);
+        this.amenities.addAll(amenities);
+        this.favourite = favourite;
     }
 
     public Name getName() {
@@ -53,6 +70,14 @@ public class StudySpot {
 
     public Address getAddress() {
         return address;
+    }
+
+    public Favourite getFavourite() {
+        return favourite;
+    }
+
+    public boolean isFavourite() {
+        return favourite.isFavourite();
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedStudySpot.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedStudySpot.java
@@ -13,6 +13,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.amenity.Amenity;
 import seedu.address.model.studyspot.Address;
 import seedu.address.model.studyspot.Email;
+import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.Rating;
 import seedu.address.model.studyspot.StudySpot;
@@ -29,6 +30,7 @@ class JsonAdaptedStudySpot {
     private final String rating;
     private final String email;
     private final String address;
+    private final String favourite;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
     private final List<JsonAdaptedAmenity> amenities = new ArrayList<>();
 
@@ -38,12 +40,13 @@ class JsonAdaptedStudySpot {
     @JsonCreator
     public JsonAdaptedStudySpot(@JsonProperty("name") String name, @JsonProperty("rating") String rating,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+            @JsonProperty("favourite") String favourite, @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
             @JsonProperty("amenities") List<JsonAdaptedAmenity> amenities) {
         this.name = name;
         this.rating = rating;
         this.email = email;
         this.address = address;
+        this.favourite = favourite;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -60,6 +63,7 @@ class JsonAdaptedStudySpot {
         rating = source.getRating().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
+        favourite = source.getFavourite().value;
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -116,9 +120,19 @@ class JsonAdaptedStudySpot {
         }
         final Address modelAddress = new Address(address);
 
+        if (favourite == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Favourite.class.getSimpleName()));
+        }
+        if (!Favourite.isValidFavourite(favourite)) {
+            throw new IllegalValueException(Favourite.MESSAGE_CONSTRAINTS);
+        }
+        final Favourite modelFavourite = new Favourite(Boolean.parseBoolean(favourite));
+
         final Set<Tag> modelTags = new HashSet<>(studySpotTags);
         final Set<Amenity> modelAmenities = new HashSet<>(studySpotAmenities);
-        return new StudySpot(modelName, modelRating, modelEmail, modelAddress, modelTags, modelAmenities);
+        return new StudySpot(modelName, modelRating, modelEmail, modelAddress, modelFavourite,
+                modelTags, modelAmenities);
     }
 
 }

--- a/src/main/java/seedu/address/ui/StudySpotCard.java
+++ b/src/main/java/seedu/address/ui/StudySpotCard.java
@@ -34,6 +34,8 @@ public class StudySpotCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
+    private Label favourite;
+    @FXML
     private Label rating;
     @FXML
     private Label address;
@@ -50,6 +52,7 @@ public class StudySpotCard extends UiPart<Region> {
         this.studySpot = studySpot;
         id.setText(displayedIndex + ". ");
         name.setText(studySpot.getName().fullName);
+        favourite.setText(studySpot.isFavourite() ? "♥" : "");
         rating.setText(ratingDisplay(studySpot.getRating()));
         address.setText(studySpot.getAddress().value);
         email.setText(studySpot.getEmail().value);

--- a/src/main/java/seedu/address/ui/StudySpotCard.java
+++ b/src/main/java/seedu/address/ui/StudySpotCard.java
@@ -52,7 +52,7 @@ public class StudySpotCard extends UiPart<Region> {
         this.studySpot = studySpot;
         id.setText(displayedIndex + ". ");
         name.setText(studySpot.getName().fullName);
-        favourite.setText(studySpot.isFavourite() ? "♥" : "");
+        favourite.setVisible(studySpot.isFavourite());
         rating.setText(ratingDisplay(studySpot.getRating()));
         address.setText(studySpot.getAddress().value);
         email.setText(studySpot.getEmail().value);

--- a/src/main/resources/view/StudySpotListCard.fxml
+++ b/src/main/resources/view/StudySpotListCard.fxml
@@ -57,7 +57,7 @@
       </VBox>
 
       <VBox GridPane.columnIndex="2" alignment="TOP_RIGHT" >
-        <Label fx:id="favourite" styleClass="icon_container, cell_small_label" alignment="TOP_RIGHT"/>
+        <Label fx:id="favourite" text="♥" styleClass="icon_container, cell_small_label" alignment="TOP_RIGHT"/>
         <Region VBox.vgrow="ALWAYS" /> <!-- spacer -->
         <HBox spacing="4" alignment="CENTER_RIGHT">
           <Label styleClass="cell_big_label" text="30" />

--- a/src/main/resources/view/StudySpotListCard.fxml
+++ b/src/main/resources/view/StudySpotListCard.fxml
@@ -57,7 +57,7 @@
       </VBox>
 
       <VBox GridPane.columnIndex="2" alignment="TOP_RIGHT" >
-        <Label styleClass="icon_container, cell_small_label" text="♥" alignment="TOP_RIGHT"/>
+        <Label fx:id="favourite" styleClass="icon_container, cell_small_label" alignment="TOP_RIGHT"/>
         <Region VBox.vgrow="ALWAYS" /> <!-- spacer -->
         <HBox spacing="4" alignment="CENTER_RIGHT">
           <Label styleClass="cell_big_label" text="30" />

--- a/src/test/data/JsonSerializableStudyTrackerTest/duplicateStudySpotStudyTracker.json
+++ b/src/test/data/JsonSerializableStudyTrackerTest/duplicateStudySpotStudyTracker.json
@@ -4,11 +4,13 @@
     "rating": "3",
     "email": "-",
     "address": "SoC COM2, B1",
+    "favourite" : "false",
     "tagged": [ "noisy" ]
   }, {
     "name": "COM2 Tech Hangout",
     "rating": "2",
     "email": "-",
-    "address": "NUS School of Computing, COM2, Basement 1"
+    "address": "NUS School of Computing, COM2, Basement 1",
+    "favourite" : "false"
   } ]
 }

--- a/src/test/data/JsonSerializableStudyTrackerTest/invalidStudySpotStudyTracker.json
+++ b/src/test/data/JsonSerializableStudyTrackerTest/invalidStudySpotStudyTracker.json
@@ -3,6 +3,7 @@
     "name": "Hans Muster",
     "rating": "9482424",
     "email": "invalid@email!3e",
-    "address": "4th street"
+    "address": "4th street",
+    "favourite" : "false"
   } ]
 }

--- a/src/test/data/JsonSerializableStudyTrackerTest/typicalStudySpotsStudyTracker.json
+++ b/src/test/data/JsonSerializableStudyTrackerTest/typicalStudySpotsStudyTracker.json
@@ -5,6 +5,7 @@
     "rating" : "4",
     "email" : "-",
     "address" : "UTown",
+    "favourite" : "false",
     "tagged" : [ "coffee" ],
     "amenities" : [ "wifi" ]
   }, {
@@ -12,6 +13,7 @@
     "rating" : "3",
     "email" : "-",
     "address" : "NUS, Central Library",
+    "favourite" : "false",
     "tagged" : [ "cold", "quiet" ],
     "amenities" : [ "wifi" ]
   }, {
@@ -19,6 +21,7 @@
     "rating" : "2",
     "email" : "-",
     "address" : "NUS Computing",
+    "favourite" : "false",
     "tagged" : [ ],
     "amenities" : [ "wifi" ]
   }, {
@@ -26,6 +29,7 @@
     "rating" : "3",
     "email" : "Frontier email",
     "address" : "NUS Science Faculty",
+    "favourite" : "false",
     "tagged" : [ "crowded" ],
     "amenities" : [ ]
   }, {
@@ -33,6 +37,7 @@
     "rating" : "3",
     "email" : "-",
     "address" : "NUS, Yusof Ishak House Level 3",
+    "favourite" : "false",
     "tagged" : [ "cold" ],
     "amenities" : [ "wifi" ]
   },{
@@ -40,6 +45,7 @@
     "rating" : "4",
     "email" : "-",
     "address" : "Utown",
+    "favourite" : "false",
     "tagged" : [ ],
     "amenities" : [ "wifi" ]
   }, {
@@ -47,6 +53,7 @@
     "rating" : "5",
     "email" : "-",
     "address" : "NUS COM2",
+    "favourite" : "false",
     "tagged" : [ ],
     "amenities" : [ ]
   } ]

--- a/src/test/data/JsonStudyTrackerStorageTest/invalidAndValidStudySpotStudyTracker.json
+++ b/src/test/data/JsonStudyTrackerStorageTest/invalidAndValidStudySpotStudyTracker.json
@@ -3,11 +3,13 @@
     "name": "Valid Study Spot",
     "rating": "3",
     "email": "blank email",
-    "address": "NUS"
+    "address": "NUS",
+    "favourite" : "false"
   }, {
     "name": "Study Spot With Invalid rating Field",
     "rating": "100 amazing",
     "email": "blank email",
-    "address": "NUS"
+    "address": "NUS",
+    "favourite" : "false"
   } ]
 }

--- a/src/test/data/JsonStudyTrackerStorageTest/invalidStudySpotStudyTracker.json
+++ b/src/test/data/JsonStudyTrackerStorageTest/invalidStudySpotStudyTracker.json
@@ -3,6 +3,7 @@
     "name": "Study Spot with invalid name field: *bucks @ ut0wN!",
     "rating": "2",
     "email": "blank email",
-    "address": "UTown Green"
+    "address": "UTown Green",
+    "favourite" : "false"
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -145,12 +145,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public void addStudySpotToFavourites(StudySpot studySpot) {
+        public StudySpot addStudySpotToFavourites(StudySpot studySpot) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void removeStudySpotFromFavourites(StudySpot studySpot) {
+        public StudySpot removeStudySpotFromFavourites(StudySpot studySpot) {
             throw new AssertionError("This method should not be called.");
 
         }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -140,6 +140,22 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean isFavouriteStudySpot(StudySpot studySpot) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addStudySpotToFavourites(StudySpot studySpot) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void removeStudySpotFromFavourites(StudySpot studySpot) {
+            throw new AssertionError("This method should not be called.");
+
+        }
+
+        @Override
         public ObservableList<StudySpot> getFilteredStudySpotList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -176,7 +176,7 @@ public class EditCommandTest {
         EditStudySpotDescriptor descriptor = new EditStudySpotDescriptorBuilder().withName(VALID_NAME_DECK).build();
         EditCommand editCommand = new EditCommand(notInTypicalStudySpots, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_EDIT_NAME);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_NAME_NOT_FOUND);
     }
 
     @Test
@@ -186,7 +186,7 @@ public class EditCommandTest {
         EditStudySpotDescriptor descriptor = new EditStudySpotDescriptorBuilder().withName(VALID_NAME_DECK).build();
         EditCommand editCommand = new EditCommand(notInTypicalStudySpots, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_EDIT_NAME);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_NAME_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SPOT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SPOT;
+import static seedu.address.testutil.TypicalStudySpots.getTypicalStudyTracker;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.studyspot.StudySpot;
+import seedu.address.testutil.StudySpotBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code FavouriteCommand}.
+ */
+public class FavouriteCommandTest {
+
+    private Model model = new ModelManager(getTypicalStudyTracker(), new UserPrefs());
+
+    @Test
+    public void execute_validNameUnfilteredList_success() {
+        StudySpot studySpotToFavourite = model.getFilteredStudySpotList().get(INDEX_FIRST_SPOT.getZeroBased());
+        FavouriteCommand favouriteCommand = new FavouriteCommand(studySpotToFavourite.getName());
+
+        String expectedMessage =
+                String.format(FavouriteCommand.MESSAGE_FAVOURITE_STUDYSPOT_SUCCESS, studySpotToFavourite.getName());
+
+        ModelManager expectedModel = new ModelManager(model.getStudyTracker(), new UserPrefs());
+        expectedModel.addStudySpotToFavourites(studySpotToFavourite);
+
+        assertCommandSuccess(favouriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidNameUnfilteredList_throwsCommandException() {
+        StudySpot invalidStudySpot = new StudySpotBuilder().build();
+        assertFalse(model.hasStudySpot(invalidStudySpot));
+        FavouriteCommand favouriteCommand = new FavouriteCommand(invalidStudySpot.getName());
+
+        assertCommandFailure(favouriteCommand, model, Messages.MESSAGE_NAME_NOT_FOUND);
+    }
+
+    @Test
+    public void equals() {
+        StudySpot firstStudySpot = model.getFilteredStudySpotList().get(INDEX_FIRST_SPOT.getZeroBased());
+        StudySpot secondStudySpot = model.getFilteredStudySpotList().get(INDEX_SECOND_SPOT.getZeroBased());
+        FavouriteCommand favouriteFirstCommand = new FavouriteCommand(firstStudySpot.getName());
+        FavouriteCommand favouriteSecondCommand = new FavouriteCommand(secondStudySpot.getName());
+
+        // same object -> returns true
+        assertTrue(favouriteFirstCommand.equals(favouriteFirstCommand));
+
+        // same values -> returns true
+        FavouriteCommand favouriteFirstCommandCopy = new FavouriteCommand(firstStudySpot.getName());
+        assertTrue(favouriteFirstCommand.equals(favouriteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(favouriteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(favouriteFirstCommand.equals(null));
+
+        // different study spot -> returns false
+        assertFalse(favouriteFirstCommand.equals(favouriteSecondCommand));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
@@ -49,6 +49,19 @@ public class FavouriteCommandTest {
     }
 
     @Test
+    public void execute_studySpotAlreadyAFavourite_throwsCommandException() {
+        StudySpot invalidStudySpot = new StudySpotBuilder().withFavourite(true).build();
+        assertTrue(invalidStudySpot.isFavourite());
+        model.addStudySpot(invalidStudySpot);
+        FavouriteCommand favouriteCommand = new FavouriteCommand(invalidStudySpot.getName());
+
+        String expectedMessage =
+                String.format(FavouriteCommand.MESSAGE_FAVOURITE_REPEATSTUDYSPOT_FAIL, invalidStudySpot.getName());
+
+        assertCommandFailure(favouriteCommand, model, expectedMessage);
+    }
+
+    @Test
     public void equals() {
         StudySpot firstStudySpot = model.getFilteredStudySpotList().get(INDEX_FIRST_SPOT.getZeroBased());
         StudySpot secondStudySpot = model.getFilteredStudySpotList().get(INDEX_SECOND_SPOT.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/UnfavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnfavouriteCommandTest.java
@@ -49,6 +49,18 @@ public class UnfavouriteCommandTest {
     }
 
     @Test
+    public void execute_studySpotIsNotAFavourite_throwsCommandException() {
+        StudySpot invalidStudySpot = new StudySpotBuilder().withFavourite(false).build();
+        assertFalse(invalidStudySpot.isFavourite());
+        model.addStudySpot(invalidStudySpot);
+        UnfavouriteCommand unfavouriteCommand = new UnfavouriteCommand(invalidStudySpot.getName());
+
+        String expectedMessage =
+                String.format(UnfavouriteCommand.MESSAGE_UNFAVOURITE_REPEATSTUDYSPOT_FAIL, invalidStudySpot.getName());
+
+        assertCommandFailure(unfavouriteCommand, model, expectedMessage);
+    }
+    @Test
     public void equals() {
         StudySpot firstStudySpot = model.getFilteredStudySpotList().get(INDEX_FIRST_SPOT.getZeroBased());
         StudySpot secondStudySpot = model.getFilteredStudySpotList().get(INDEX_SECOND_SPOT.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/UnfavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnfavouriteCommandTest.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SPOT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SPOT;
+import static seedu.address.testutil.TypicalStudySpots.getTypicalStudyTracker;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.studyspot.StudySpot;
+import seedu.address.testutil.StudySpotBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code UnfavouriteCommand}.
+ */
+public class UnfavouriteCommandTest {
+
+    private Model model = new ModelManager(getTypicalStudyTracker(), new UserPrefs());
+
+    @Test
+    public void execute_validNameUnfilteredList_success() {
+        StudySpot studySpot = model.getFilteredStudySpotList().get(INDEX_FIRST_SPOT.getZeroBased());
+        model.addStudySpotToFavourites(studySpot);
+        UnfavouriteCommand unfavouriteCommand = new UnfavouriteCommand(studySpot.getName());
+
+        String expectedMessage =
+                String.format(UnfavouriteCommand.MESSAGE_UNFAVOURITE_STUDYSPOT_SUCCESS, studySpot.getName());
+
+        ModelManager expectedModel = new ModelManager(getTypicalStudyTracker(), new UserPrefs());
+
+        assertCommandSuccess(unfavouriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidNameUnfilteredList_throwsCommandException() {
+        StudySpot invalidStudySpot = new StudySpotBuilder().build();
+        assertFalse(model.hasStudySpot(invalidStudySpot));
+        UnfavouriteCommand unfavouriteCommand = new UnfavouriteCommand(invalidStudySpot.getName());
+
+        assertCommandFailure(unfavouriteCommand, model, Messages.MESSAGE_NAME_NOT_FOUND);
+    }
+
+    @Test
+    public void equals() {
+        StudySpot firstStudySpot = model.getFilteredStudySpotList().get(INDEX_FIRST_SPOT.getZeroBased());
+        StudySpot secondStudySpot = model.getFilteredStudySpotList().get(INDEX_SECOND_SPOT.getZeroBased());
+        UnfavouriteCommand unfavouriteFirstCommand = new UnfavouriteCommand(firstStudySpot.getName());
+        UnfavouriteCommand unfavouriteSecondCommand = new UnfavouriteCommand(secondStudySpot.getName());
+
+        // same object -> returns true
+        assertTrue(unfavouriteFirstCommand.equals(unfavouriteFirstCommand));
+
+        // same values -> returns true
+        UnfavouriteCommand favouriteFirstCommandCopy = new UnfavouriteCommand(firstStudySpot.getName());
+        assertTrue(unfavouriteFirstCommand.equals(favouriteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(unfavouriteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(unfavouriteFirstCommand.equals(null));
+
+        // different study spot -> returns false
+        assertFalse(unfavouriteFirstCommand.equals(unfavouriteSecondCommand));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/FavouriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FavouriteCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalStudySpots.STARBUCKS;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.FavouriteCommand;
 import seedu.address.model.studyspot.Name;
 

--- a/src/test/java/seedu/address/logic/parser/FavouriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FavouriteCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalStudySpots.STARBUCKS;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.FavouriteCommand;
+import seedu.address.model.studyspot.Name;
+
+public class FavouriteCommandParserTest {
+
+    private FavouriteCommandParser parser = new FavouriteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsFavouriteCommand() {
+        String userInput = " " + PREFIX_NAME + STARBUCKS.getName().fullName;
+        assertParseSuccess(parser, userInput, new FavouriteCommand(STARBUCKS.getName()));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        String userInput = " " + PREFIX_NAME;
+        assertParseFailure(parser, userInput, Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_missingArgs_throwsParseException() {
+        assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavouriteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/StudyTrackerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StudyTrackerParserTest.java
@@ -4,22 +4,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SPOT;
+import static seedu.address.testutil.TypicalStudySpots.STARBUCKS;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
-
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FavouriteCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UnfavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.studyspot.NameContainsKeywordsPredicate;
 import seedu.address.model.studyspot.StudySpot;
@@ -60,6 +63,20 @@ public class StudyTrackerParserTest {
     //        assertEquals(new EditCommand(new Name("Test"), descriptor), command);
     //        //todo discrepancies in amenities and addedamenities
     //    }
+
+    @Test
+    public void parseCommand_favourite() throws Exception {
+        FavouriteCommand command = (FavouriteCommand) parser.parseCommand(
+                FavouriteCommand.COMMAND_WORD + " " + PREFIX_NAME + STARBUCKS.getName());
+        assertEquals(new FavouriteCommand(STARBUCKS.getName()), command);
+    }
+
+    @Test
+    public void parseCommand_unfavourite() throws Exception {
+        UnfavouriteCommand command = (UnfavouriteCommand) parser.parseCommand(
+                UnfavouriteCommand.COMMAND_WORD + " " + PREFIX_NAME + STARBUCKS.getName());
+        assertEquals(new UnfavouriteCommand(STARBUCKS.getName()), command);
+    }
 
     @Test
     public void parseCommand_exit() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/StudyTrackerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StudyTrackerParserTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;

--- a/src/test/java/seedu/address/logic/parser/UnfavouriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnfavouriteCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalStudySpots.STARBUCKS;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.UnfavouriteCommand;
+import seedu.address.model.studyspot.Name;
+
+public class UnfavouriteCommandParserTest {
+
+    private UnfavouriteCommandParser parser = new UnfavouriteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsUnfavouriteCommand() {
+        String userInput = " " + PREFIX_NAME + STARBUCKS.getName().fullName;
+        assertParseSuccess(parser, userInput, new UnfavouriteCommand(STARBUCKS.getName()));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        String userInput = " " + PREFIX_NAME;
+        assertParseFailure(parser, userInput, Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_missingArgs_throwsParseException() {
+        assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                UnfavouriteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UnfavouriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnfavouriteCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalStudySpots.STARBUCKS;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.UnfavouriteCommand;
 import seedu.address.model.studyspot.Name;
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -13,10 +13,11 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
-
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.studyspot.NameContainsKeywordsPredicate;
+import seedu.address.model.studyspot.StudySpot;
 import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.StudySpotBuilder;
 
 public class ModelManagerTest {
 
@@ -80,6 +81,21 @@ public class ModelManagerTest {
     @Test
     public void hasStudySpot_studySpotNotInAddressBook_returnsFalse() {
         assertFalse(modelManager.hasStudySpot(STARBUCKS));
+    }
+
+    @Test
+    public void addStudySpot_studySpotNotAFavourite_returnsFalse() {
+        assertFalse(STARBUCKS.isFavourite());
+        modelManager.addStudySpot(STARBUCKS);
+        assertFalse(modelManager.isFavouriteStudySpot(STARBUCKS));
+    }
+
+    @Test
+    public void addStudySpot_studySpotIsAFavourite_returnsTrue() {
+        StudySpot test = new StudySpotBuilder(STARBUCKS).withFavourite(true).build();
+        assertTrue(test.isFavourite());
+        modelManager.addStudySpot(test);
+        assertTrue(modelManager.isFavouriteStudySpot(test));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -89,6 +89,24 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void isFavouriteStudySpot_nullStudySpot_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.isFavouriteStudySpot(null));
+    }
+
+    @Test
+    public void isFavouriteStudySpot_studySpotNotInFavourites_returnsFalse() {
+        modelManager.addStudySpot(STARBUCKS);
+        assertFalse(modelManager.isFavouriteStudySpot(STARBUCKS));
+    }
+
+    @Test
+    public void isFavouriteStudySpot_studySpotInFavourites_returnsTrue() {
+        modelManager.addStudySpot(STARBUCKS);
+        modelManager.addStudySpotToFavourites(STARBUCKS);
+        assertTrue(modelManager.isFavouriteStudySpot(STARBUCKS));
+    }
+
+    @Test
     public void getFilteredStudySpotList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredStudySpotList().remove(0));
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.studyspot.NameContainsKeywordsPredicate;
 import seedu.address.model.studyspot.StudySpot;

--- a/src/test/java/seedu/address/model/StudyTrackerTest.java
+++ b/src/test/java/seedu/address/model/StudyTrackerTest.java
@@ -99,6 +99,12 @@ public class StudyTrackerTest {
         public ObservableList<StudySpot> getStudySpotList() {
             return studySpots;
         }
+
+        //TODO
+        @Override
+        public ObservableList<StudySpot> getFavouriteStudySpotList() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
 }

--- a/src/test/java/seedu/address/model/StudyTrackerTest.java
+++ b/src/test/java/seedu/address/model/StudyTrackerTest.java
@@ -37,7 +37,7 @@ public class StudyTrackerTest {
     }
 
     @Test
-    public void resetData_withValidReadOnlyAddressBook_replacesData() {
+    public void resetData_withValidReadOnlyStudyTracker_replacesData() {
         StudyTracker newData = getTypicalStudyTracker();
         studyTracker.resetData(newData);
         assertEquals(newData, studyTracker);
@@ -61,23 +61,60 @@ public class StudyTrackerTest {
     }
 
     @Test
-    public void hasStudySpot_studySpotNotInAddressBook_returnsFalse() {
+    public void hasStudySpot_studySpotNotInStudyTracker_returnsFalse() {
         assertFalse(studyTracker.hasStudySpot(STARBUCKS));
     }
 
     @Test
-    public void hasStudySpot_studySpotInAddressBook_returnsTrue() {
+    public void hasStudySpot_studySpotInStudyTracker_returnsTrue() {
         studyTracker.addStudySpot(STARBUCKS);
         assertTrue(studyTracker.hasStudySpot(STARBUCKS));
     }
 
     @Test
-    public void hasStudySpot_studySpotWithSameIdentityFieldsInAddressBook_returnsTrue() {
+    public void hasStudySpot_studySpotWithSameIdentityFieldsInStudyTracker_returnsTrue() {
         studyTracker.addStudySpot(STARBUCKS);
         StudySpot editedStarbucks = new StudySpotBuilder(STARBUCKS)
                 .withAddress(VALID_ADDRESS_DECK).withTags(VALID_TAG_QUIET)
                 .build();
         assertTrue(studyTracker.hasStudySpot(editedStarbucks));
+    }
+
+    @Test
+    public void addStudySpotToFavourite_notInStudyTracker_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> studyTracker.addStudySpotToFavourites(STARBUCKS));
+    }
+
+    @Test
+    public void addStudySpotToFavourite_studySpotInFavourites_returnsTrue() {
+        studyTracker.addStudySpot(STARBUCKS);
+        studyTracker.addStudySpotToFavourites(STARBUCKS);
+        StudySpot favouritedStarbucks = new StudySpotBuilder(STARBUCKS).withFavourite(true).build();
+        assertTrue(studyTracker.getFavouriteStudySpotList().contains(favouritedStarbucks));
+    }
+
+    @Test
+    public void removeStudySpotToFavourite_studySpotInFavourites_returnsTrue() {
+        studyTracker.addStudySpot(STARBUCKS);
+        studyTracker.addStudySpotToFavourites(STARBUCKS);
+        StudySpot favouritedStarbucks = new StudySpotBuilder(STARBUCKS).withFavourite(true).build();
+        assertTrue(studyTracker.getFavouriteStudySpotList().contains(favouritedStarbucks));
+        studyTracker.removeStudySpotFromFavourites(favouritedStarbucks);
+        assertTrue(studyTracker.getFavouriteStudySpotList().isEmpty());
+    }
+
+    @Test
+    public void isFavouriteStudySpot_notInFavourites_returnsFalse() {
+        studyTracker.addStudySpot(STARBUCKS);
+        assertFalse(studyTracker.isFavouriteStudySpot(STARBUCKS));
+    }
+
+
+    @Test
+    public void isFavouriteStudySpot_inFavourites_returnsTrue() {
+        studyTracker.addStudySpot(STARBUCKS);
+        studyTracker.addStudySpotToFavourites(STARBUCKS);
+        assertTrue(studyTracker.isFavouriteStudySpot(STARBUCKS));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/studyspot/FavouriteTest.java
+++ b/src/test/java/seedu/address/model/studyspot/FavouriteTest.java
@@ -1,0 +1,48 @@
+package seedu.address.model.studyspot;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class FavouriteTest {
+
+    @Test
+    public void isValidFavourite() {
+        // null favourite
+        assertThrows(NullPointerException.class, () -> Favourite.isValidFavourite(null));
+
+        // invalid favourite
+        assertFalse(Favourite.isValidFavourite("false1"));
+        assertFalse(Favourite.isValidFavourite("null"));
+        assertFalse(Favourite.isValidFavourite("1"));
+        assertFalse(Favourite.isValidFavourite("0"));
+
+        // valid favourite
+        assertTrue(Favourite.isValidFavourite("true"));
+        assertTrue(Favourite.isValidFavourite("false"));
+    }
+
+    @Test
+    public void equals() {
+        Favourite favouriteTrue = new Favourite(true);
+        Favourite favouriteFalse = new Favourite(false);
+
+        // same object -> returns true
+        assertTrue(favouriteTrue.equals(favouriteTrue));
+
+        // same values -> returns true
+        Favourite favouriteTrueCopy = new Favourite(true);
+        assertTrue(favouriteTrue.equals(favouriteTrueCopy));
+
+        // different types -> returns false
+        assertFalse(favouriteTrue.equals(1));
+
+        // null -> returns false
+        assertFalse(favouriteTrue.equals(null));
+
+        // different favourite -> returns false
+        assertFalse(favouriteTrue.equals(favouriteFalse));
+    }
+}

--- a/src/test/java/seedu/address/model/studyspot/StudySpotTest.java
+++ b/src/test/java/seedu/address/model/studyspot/StudySpotTest.java
@@ -34,7 +34,7 @@ public class StudySpotTest {
         // same name, all other attributes different -> returns true
         StudySpot editedStarbucks = new StudySpotBuilder(STARBUCKS)
                 .withRating(VALID_RATING_DECK).withEmail(VALID_EMAIL_DECK)
-                .withAddress(VALID_ADDRESS_DECK).withTags(VALID_TAG_QUIET).build();
+                .withAddress(VALID_ADDRESS_DECK).withFavourite(true).withTags(VALID_TAG_QUIET).build();
         assertTrue(STARBUCKS.isSameStudySpot(editedStarbucks));
 
         // different name, all other attributes same -> returns false
@@ -83,6 +83,10 @@ public class StudySpotTest {
 
         // different address -> returns false
         editedStarbucks = new StudySpotBuilder(STARBUCKS).withAddress(VALID_ADDRESS_DECK).build();
+        assertFalse(STARBUCKS.equals(editedStarbucks));
+
+        // different favourite -> returns false
+        editedStarbucks = new StudySpotBuilder(STARBUCKS).withFavourite(true).build();
         assertFalse(STARBUCKS.equals(editedStarbucks));
 
         // different tags -> returns false

--- a/src/test/java/seedu/address/storage/JsonAdaptedStudySpotTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStudySpotTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.studyspot.Address;
 import seedu.address.model.studyspot.Email;
+import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.Rating;
 
@@ -22,6 +23,7 @@ public class JsonAdaptedStudySpotTest {
     private static final String INVALID_RATING = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_FAVOURITE = "falseortrue";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_AMENITY = "carpark";
 
@@ -29,6 +31,7 @@ public class JsonAdaptedStudySpotTest {
     private static final String VALID_RATING = CENTRAL_LIBRARY.getRating().toString();
     private static final String VALID_EMAIL = CENTRAL_LIBRARY.getEmail().toString();
     private static final String VALID_ADDRESS = CENTRAL_LIBRARY.getAddress().toString();
+    private static final String VALID_FAVOURITE = CENTRAL_LIBRARY.getFavourite().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = CENTRAL_LIBRARY.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -45,8 +48,8 @@ public class JsonAdaptedStudySpotTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedStudySpot studySpot =
-                new JsonAdaptedStudySpot(INVALID_NAME, VALID_RATING, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        VALID_AMENITIES);
+                new JsonAdaptedStudySpot(INVALID_NAME, VALID_RATING, VALID_EMAIL, VALID_ADDRESS, VALID_FAVOURITE,
+                        VALID_TAGS, VALID_AMENITIES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, studySpot::toModelType);
     }
@@ -54,7 +57,7 @@ public class JsonAdaptedStudySpotTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedStudySpot studySpot = new JsonAdaptedStudySpot(null, VALID_RATING,
-                VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_AMENITIES);
+                VALID_EMAIL, VALID_ADDRESS, VALID_FAVOURITE, VALID_TAGS, VALID_AMENITIES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, studySpot::toModelType);
     }
@@ -62,8 +65,8 @@ public class JsonAdaptedStudySpotTest {
     @Test
     public void toModelType_invalidRating_throwsIllegalValueException() {
         JsonAdaptedStudySpot studySpot =
-                new JsonAdaptedStudySpot(VALID_NAME, INVALID_RATING, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        VALID_AMENITIES);
+                new JsonAdaptedStudySpot(VALID_NAME, INVALID_RATING, VALID_EMAIL, VALID_ADDRESS, VALID_FAVOURITE,
+                        VALID_TAGS, VALID_AMENITIES);
         String expectedMessage = Rating.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, studySpot::toModelType);
     }
@@ -71,7 +74,7 @@ public class JsonAdaptedStudySpotTest {
     @Test
     public void toModelType_nullRating_throwsIllegalValueException() {
         JsonAdaptedStudySpot studySpot = new JsonAdaptedStudySpot(VALID_NAME, null, VALID_EMAIL,
-                VALID_ADDRESS, VALID_TAGS, VALID_AMENITIES);
+                VALID_ADDRESS, VALID_FAVOURITE, VALID_TAGS, VALID_AMENITIES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Rating.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, studySpot::toModelType);
     }
@@ -88,7 +91,7 @@ public class JsonAdaptedStudySpotTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedStudySpot studySpot = new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, null,
-                VALID_ADDRESS, VALID_TAGS, VALID_AMENITIES);
+                VALID_ADDRESS, VALID_FAVOURITE, VALID_TAGS, VALID_AMENITIES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, studySpot::toModelType);
     }
@@ -96,8 +99,8 @@ public class JsonAdaptedStudySpotTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedStudySpot studySpot =
-                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS,
-                        VALID_AMENITIES);
+                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, INVALID_ADDRESS, VALID_FAVOURITE,
+                        VALID_TAGS, VALID_AMENITIES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, studySpot::toModelType);
     }
@@ -105,9 +108,27 @@ public class JsonAdaptedStudySpotTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedStudySpot studySpot =
-                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, null, VALID_TAGS,
+                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, null, VALID_FAVOURITE, VALID_TAGS,
                 VALID_AMENITIES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, studySpot::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidFavourite_throwsIllegalValueException() {
+        JsonAdaptedStudySpot studySpot =
+                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, VALID_ADDRESS, INVALID_FAVOURITE,
+                        VALID_TAGS, VALID_AMENITIES);
+        String expectedMessage = Favourite.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, studySpot::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullFavourite_throwsIllegalValueException() {
+        JsonAdaptedStudySpot studySpot =
+                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, VALID_ADDRESS, null,
+                        VALID_TAGS, VALID_AMENITIES);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Favourite.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, studySpot::toModelType);
     }
 
@@ -116,8 +137,8 @@ public class JsonAdaptedStudySpotTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedStudySpot studySpot =
-                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, VALID_ADDRESS, invalidTags,
-                        VALID_AMENITIES);
+                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, VALID_ADDRESS, VALID_FAVOURITE,
+                        invalidTags, VALID_AMENITIES);
         assertThrows(IllegalValueException.class, studySpot::toModelType);
     }
 
@@ -126,8 +147,8 @@ public class JsonAdaptedStudySpotTest {
         List<JsonAdaptedAmenity> invalidAmenityTypes = new ArrayList<>(VALID_AMENITIES);
         invalidAmenityTypes.add(new JsonAdaptedAmenity(INVALID_AMENITY));
         JsonAdaptedStudySpot studySpot =
-                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
-                        invalidAmenityTypes);
+                new JsonAdaptedStudySpot(VALID_NAME, VALID_RATING, VALID_EMAIL, VALID_ADDRESS, VALID_FAVOURITE,
+                        VALID_TAGS, invalidAmenityTypes);
         assertThrows(IllegalValueException.class, studySpot::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/StudySpotBuilder.java
+++ b/src/test/java/seedu/address/testutil/StudySpotBuilder.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import seedu.address.model.amenity.Amenity;
 import seedu.address.model.studyspot.Address;
 import seedu.address.model.studyspot.Email;
+import seedu.address.model.studyspot.Favourite;
 import seedu.address.model.studyspot.Name;
 import seedu.address.model.studyspot.Rating;
 import seedu.address.model.studyspot.StudySpot;
@@ -21,11 +22,13 @@ public class StudySpotBuilder {
     public static final String DEFAULT_RATING = "3";
     public static final String DEFAULT_EMAIL = "-";
     public static final String DEFAULT_ADDRESS = "NUS School of Computing";
+    public static final boolean DEFAULT_FAVOURITE = false;
 
     private Name name;
     private Rating rating;
     private Email email;
     private Address address;
+    private Favourite favourite;
     private Set<Tag> tags;
     private Set<Amenity> amenities;
 
@@ -37,6 +40,7 @@ public class StudySpotBuilder {
         rating = new Rating(DEFAULT_RATING);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
+        favourite = new Favourite(DEFAULT_FAVOURITE);
         tags = new HashSet<>();
         amenities = new HashSet<>();
     }
@@ -49,6 +53,7 @@ public class StudySpotBuilder {
         rating = studySpotToCopy.getRating();
         email = studySpotToCopy.getEmail();
         address = studySpotToCopy.getAddress();
+        favourite = studySpotToCopy.getFavourite();
         tags = new HashSet<>(studySpotToCopy.getTags());
         amenities = new HashSet<>(studySpotToCopy.getAmenities());
     }
@@ -102,8 +107,16 @@ public class StudySpotBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Favourite} of the {@code StudySpot} that we are building.
+     */
+    public StudySpotBuilder withFavourite(boolean favourite) {
+        this.favourite = new Favourite(favourite);
+        return this;
+    }
+
     public StudySpot build() {
-        return new StudySpot(name, rating, email, address, tags, amenities);
+        return new StudySpot(name, rating, email, address, favourite, tags, amenities);
     }
 
 }


### PR DESCRIPTION
StudyTracker does not allow adding study spots to favourites. #31 

Let's,
* add a new field `Favourite` to `StudySpot`.
* add a new field 'favouriteStudySpots' to keep track of favourites.

- [x] Implemented `Favourite`, `FavouriteCommand`, `UnfavouriteCommand` classes
- [x] Updated `ModelManager` and `StudyTracker` classes to support fav/unfav operations
- [x] Wrote new tests for `Favourite`, `FavouriteCommand`, `UnfavouriteCommand`
- [x] Updated tests for `ModelManager` and `StudyTracker`
- [x] Integrate Favourites into GUI 


Update User Guide and Developer Guide - Will open another pull request

**Consideration:**
* Did not implement a limit on number of favourites