### PR TITLE
Fix favourites

### DIFF
--- a/src/main/java/seedu/address/storage/JsonSerializableStudyTracker.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableStudyTracker.java
@@ -54,6 +54,9 @@ class JsonSerializableStudyTracker {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_STUDYSPOT);
             }
             studyTracker.addStudySpot(spot);
+            if (spot.isFavourite()) {
+                studyTracker.addStudySpotToFavourites(spot);
+            }
         }
         return studyTracker;
     }


### PR DESCRIPTION
Each study spot had their favourite status saved but it was not being added to favouritesList when initialising the app. This caused the favouritesList to remain empty.