### PR TITLE
Fix favourites list not being updated after Edit command

### DIFF
--- a/src/main/java/seedu/address/model/StudyTracker.java
+++ b/src/main/java/seedu/address/model/StudyTracker.java
@@ -96,6 +96,9 @@ public class StudyTracker implements ReadOnlyStudyTracker {
         requireNonNull(editedStudySpot);
 
         studySpots.setStudySpot(target, editedStudySpot);
+        if (editedStudySpot.isFavourite() && favouriteStudySpots.contains(target)) {
+            favouriteStudySpots.setStudySpot(target, editedStudySpot);
+        }
     }
 
     /**


### PR DESCRIPTION
When studySpots in `StudyTracker` is updated using `StudyTracker::setStudySpot`, favouriteStudySpots is not being updated as well. 