### PR TITLE
Display error message for invalid Log Commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -600,19 +600,17 @@ find library
 
 After studying at a certain StudySpot, you can `log` how many hours you have studied at this location.
 There are also various flags you can use to reset or override hours to the value of your choice.
-Use the `-r` and `-o` flags respectively, as shown
-below:
+Use the `-r`, `-o` or `-ra` flags respectively, as shown below:
 
 | Format     | Function |
 | ----------- | ----------- |
 | `log n/NAME* hr/NUM_OF_HOURS*` | Adds the given `NUM_OF_HOURS` to the original studied hours at a study spot |
 | `log -o n/NAME* hr/NUM_OF_HOURS*` | Overrides the current studied hours with the given `NUM_OF_HOURS`  |
 | `log -r n/NAME*` | Resets the number of studied hours at a study spot to 0 |
-| `log -r` | Resets studied hours of **ALL** study spots to 0 |
+| `log -ra` | Resets studied hours of **ALL** study spots to 0 |
 
 <div markdown="span" class="alert alert-primary">:information_source: **Note:**
-The flag `-o` stands for override, which overrides the studied hours with the provided value <br>
-The flag `-r` stands for reset, which resets the hours to 0
+As long as the flag `-ra` is present in the command, hours for all study spots will be reset to 0.  
 </div>
 
 

--- a/src/main/java/seedu/address/logic/commands/LogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogCommand.java
@@ -32,7 +32,7 @@ public class LogCommand extends Command {
             + "The -r will reset the studied hours to 0\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME* (case-insensitive) "
-            + PREFIX_HOURS + "ADDED_HOURS* (required if -r is not input) "
+            + PREFIX_HOURS + "ADDED_HOURS* (required if -ra is not input) "
             + "[-r] [-o]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Starbucks" + " " + PREFIX_HOURS + "4 ";
     public static final String MESSAGE_SUCCESS_DEFAULT = "Logged %1$S hours at %2$s!";
@@ -42,6 +42,7 @@ public class LogCommand extends Command {
     public static final String MESSAGE_SUCCESS_OVERRIDE = "Changed hours to %1$S at %2$s!";
 
     public static final String FLAG_RESET = "r";
+    public static final String FLAG_RESET_ALL = "ra";
     public static final String FLAG_OVERRIDE = "o";
 
 

--- a/src/main/java/seedu/address/logic/commands/LogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogCommand.java
@@ -37,6 +37,7 @@ public class LogCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Starbucks" + " " + PREFIX_HOURS + "4 ";
     public static final String MESSAGE_SUCCESS_DEFAULT = "Logged %1$S hours at %2$s!";
     public static final String MESSAGE_ONE_FLAG = "Please only use one flag!";
+    public static final String MESSAGE_INVALID_FLAG = "Please only use the flags -f -t -m -r!";
     public static final String MESSAGE_SUCCESS_RESET = "Reset hours at %1$s!";
     public static final String MESSAGE_SUCCESS_RESET_ALL = "Reset hours for all study spots!";
     public static final String MESSAGE_SUCCESS_OVERRIDE = "Changed hours to %1$S at %2$s!";

--- a/src/main/java/seedu/address/logic/commands/LogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogCommand.java
@@ -36,7 +36,6 @@ public class LogCommand extends Command {
             + "[-r] [-o]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Starbucks" + " " + PREFIX_HOURS + "4 ";
     public static final String MESSAGE_SUCCESS_DEFAULT = "Logged %1$S hours at %2$s!";
-    public static final String MESSAGE_INVALID_FLAG = "Please only use ONE of the flags -f -t -m -r!";
     public static final String MESSAGE_SUCCESS_RESET = "Reset hours at %1$s!";
     public static final String MESSAGE_SUCCESS_RESET_ALL = "Reset hours for all study spots!";
     public static final String MESSAGE_SUCCESS_OVERRIDE = "Changed hours to %1$S at %2$s!";

--- a/src/main/java/seedu/address/logic/commands/LogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogCommand.java
@@ -36,11 +36,11 @@ public class LogCommand extends Command {
             + "[-r] [-o]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Starbucks" + " " + PREFIX_HOURS + "4 ";
     public static final String MESSAGE_SUCCESS_DEFAULT = "Logged %1$S hours at %2$s!";
-    public static final String MESSAGE_ONE_FLAG = "Please only use one flag!";
-    public static final String MESSAGE_INVALID_FLAG = "Please only use the flags -f -t -m -r!";
+    public static final String MESSAGE_INVALID_FLAG = "Please only use ONE of the flags -f -t -m -r!";
     public static final String MESSAGE_SUCCESS_RESET = "Reset hours at %1$s!";
     public static final String MESSAGE_SUCCESS_RESET_ALL = "Reset hours for all study spots!";
     public static final String MESSAGE_SUCCESS_OVERRIDE = "Changed hours to %1$S at %2$s!";
+    public static final String MESSAGE_MISSING_HOURS = "Please enter studied hours e.g. hr/5";
 
     public static final String FLAG_RESET = "r";
     public static final String FLAG_RESET_ALL = "ra";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -8,9 +8,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OPERATING_HOURS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -59,13 +59,4 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         return new AddCommand(spot);
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
@@ -6,9 +6,9 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ALIAS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ALIAS_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FLAG;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AliasCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -52,13 +52,5 @@ public class AliasCommandParser implements Parser<AliasCommand> {
         }
 
         return new AliasCommand(false, aliasToAdd);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -3,9 +3,9 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_SPOT;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.NoSuchElementException;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -39,13 +39,5 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
 
         return new DeleteCommand(toBeDeletedSpot);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/LogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LogCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_HOURS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.LogCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -28,6 +29,23 @@ public class LogCommandParser implements Parser<LogCommand> {
         Name studySpot = null;
         StudiedHours hoursStudied;
         boolean isOverride = false;
+
+        // log hi hr/3
+        if ((!arePrefixesPresent(argMultimap, PREFIX_NAME)
+                || !argMultimap.getPreamble().isEmpty()) && !args.contains("-r")) {
+            System.out.println("Entering error1");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
+        }
+
+        // log -r hi (supposed to be log -r n/hi)
+        // won't throw error for log -r
+        System.out.println(args);
+        System.out.println(args.equals("-r"));
+        if ((!arePrefixesPresent(argMultimap, PREFIX_NAME)
+                || !argMultimap.getPreamble().isEmpty()) && !args.equals(" -r")) {
+            System.out.println("Entering error2");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
+        }
 
         try {
             boolean isNamePresent = argMultimap.getValue(PREFIX_NAME).isPresent();
@@ -57,6 +75,13 @@ public class LogCommandParser implements Parser<LogCommand> {
         } catch (NoSuchElementException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
         }
+    }
 
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/LogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LogCommandParser.java
@@ -24,12 +24,11 @@ public class LogCommandParser implements Parser<LogCommand> {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public LogCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_FLAG, PREFIX_NAME, PREFIX_HOURS);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FLAG, PREFIX_NAME, PREFIX_HOURS);
 
         // If command has no n/ and it's not a reset all command
         if ((!arePrefixesPresent(argMultimap, PREFIX_NAME)
-                || !argMultimap.getPreamble().isEmpty()) && !args.contains(" -ra")) {
+                || !argMultimap.getPreamble().isEmpty()) && !args.contains(LogCommand.FLAG_RESET_ALL)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/LogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LogCommandParser.java
@@ -45,12 +45,12 @@ public class LogCommandParser implements Parser<LogCommand> {
             if (argMultimap.getValue(PREFIX_FLAG).isPresent()) {
                 String flag = argMultimap.getValue(PREFIX_FLAG).get();
 
-                if (flag.equals("r") && isNamePresent) {
+                if (flag.equals(LogCommand.FLAG_RESET) && isNamePresent) {
                     return new LogCommand(studySpot, null, true, false,
                             false);
-                } else if (flag.equals("o") && isNamePresent && isHoursPresent) {
+                } else if (flag.equals(LogCommand.FLAG_OVERRIDE) && isNamePresent && isHoursPresent) {
                     isOverride = true;
-                } else if (flag.equals("ra")) {
+                } else if (flag.equals(LogCommand.FLAG_RESET_ALL)) {
                     return new LogCommand(studySpot, null, false, false,
                             true);
                 } else {

--- a/src/main/java/seedu/address/logic/parser/LogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LogCommandParser.java
@@ -4,9 +4,9 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FLAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOURS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.NoSuchElementException;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.LogCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -48,15 +48,17 @@ public class LogCommandParser implements Parser<LogCommand> {
                             LogCommand.MESSAGE_ONE_FLAG));
                 }
                 String flag = argMultimap.getValue(PREFIX_FLAG).get();
-                assert(flag.equals(LogCommand.FLAG_RESET) || flag.equals(LogCommand.FLAG_OVERRIDE)
-                        || flag.equals(LogCommand.FLAG_RESET_ALL));
+                if (!flag.equals(LogCommand.FLAG_RESET) && !flag.equals(LogCommand.FLAG_OVERRIDE)
+                         && !flag.equals(LogCommand.FLAG_RESET_ALL)) {
+                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            LogCommand.MESSAGE_INVALID_FLAG));
+                }
 
                 // Reset only depends on if a name is given,
                 // It should ignore any hour provided, and should not throw an error even if hour is null.
-                if (flag.equals("r")) {
-                    return new LogCommand(studySpot, null, isNamePresent, false, !isNamePresent);
-                }
-                else if (flag.equals("ra")) {
+                if (flag.equals("r") && isNamePresent) {
+                    return new LogCommand(studySpot, null, true, false, false);
+                } else if (flag.equals("ra")) {
                     return new LogCommand(studySpot, null, false, false, true);
                 } else {
                     isOverride = true;
@@ -67,13 +69,5 @@ public class LogCommandParser implements Parser<LogCommand> {
         } catch (NoSuchElementException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
         }
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/LogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LogCommandParser.java
@@ -48,17 +48,16 @@ public class LogCommandParser implements Parser<LogCommand> {
                             LogCommand.MESSAGE_ONE_FLAG));
                 }
                 String flag = argMultimap.getValue(PREFIX_FLAG).get();
-                assert(flag.equals(LogCommand.FLAG_RESET) || flag.equals(LogCommand.FLAG_OVERRIDE) || flag.equals(LogCommand.FLAG_RESET_ALL));
+                assert(flag.equals(LogCommand.FLAG_RESET) || flag.equals(LogCommand.FLAG_OVERRIDE)
+                        || flag.equals(LogCommand.FLAG_RESET_ALL));
 
                 // Reset only depends on if a name is given,
                 // It should ignore any hour provided, and should not throw an error even if hour is null.
                 if (flag.equals("r")) {
-                    return new LogCommand(studySpot, null, isNamePresent,
-                            false, !isNamePresent);
+                    return new LogCommand(studySpot, null, isNamePresent, false, !isNamePresent);
                 }
                 else if (flag.equals("ra")) {
-                    return new LogCommand(studySpot, null, false,
-                            false, true);
+                    return new LogCommand(studySpot, null, false, false, true);
                 } else {
                     isOverride = true;
                 }

--- a/src/main/java/seedu/address/logic/parser/LogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LogCommandParser.java
@@ -39,25 +39,32 @@ public class LogCommandParser implements Parser<LogCommand> {
 
         try {
             boolean isNamePresent = argMultimap.getValue(PREFIX_NAME).isPresent();
+            boolean isHoursPresent = argMultimap.getValue(PREFIX_HOURS).isPresent();
             studySpot = isNamePresent ? ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()) : null;
 
             if (argMultimap.getValue(PREFIX_FLAG).isPresent()) {
                 String flag = argMultimap.getValue(PREFIX_FLAG).get();
 
                 if (flag.equals("r") && isNamePresent) {
-                    return new LogCommand(studySpot, null, true, false, false);
-                } else if (flag.equals("o") && isNamePresent) {
+                    return new LogCommand(studySpot, null, true, false,
+                            false);
+                } else if (flag.equals("o") && isNamePresent && isHoursPresent) {
                     isOverride = true;
                 } else if (flag.equals("ra")) {
-                    return new LogCommand(studySpot, null, false, false, true);
+                    return new LogCommand(studySpot, null, false, false,
+                            true);
                 } else {
-                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                            LogCommand.MESSAGE_INVALID_FLAG));
+                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
                 }
             }
-            hoursStudied =
-                    ParserUtil.parseStudiedHours(argMultimap.getValue(PREFIX_HOURS).orElseThrow(() -> new ParseException(LogCommand.MESSAGE_MISSING_HOURS)));
-            return new LogCommand(studySpot, hoursStudied, false, isOverride, false);
+
+            if (isHoursPresent) {
+                hoursStudied =
+                        ParserUtil.parseStudiedHours(argMultimap.getValue(PREFIX_HOURS)
+                                .orElseThrow(() -> new ParseException(LogCommand.MESSAGE_MISSING_HOURS)));
+                return new LogCommand(studySpot, hoursStudied, false, isOverride, false);
+            }
+            return new LogCommand(studySpot, null, false, false, false);
         } catch (NoSuchElementException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/LogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LogCommandParser.java
@@ -42,29 +42,21 @@ public class LogCommandParser implements Parser<LogCommand> {
             studySpot = isNamePresent ? ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()) : null;
 
             if (argMultimap.getValue(PREFIX_FLAG).isPresent()) {
-                // Only one flag should be present
-                if (argMultimap.getAllValues(PREFIX_FLAG).size() != 1) {
-                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                            LogCommand.MESSAGE_ONE_FLAG));
-                }
                 String flag = argMultimap.getValue(PREFIX_FLAG).get();
-                if (!flag.equals(LogCommand.FLAG_RESET) && !flag.equals(LogCommand.FLAG_OVERRIDE)
-                         && !flag.equals(LogCommand.FLAG_RESET_ALL)) {
-                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                            LogCommand.MESSAGE_INVALID_FLAG));
-                }
 
-                // Reset only depends on if a name is given,
-                // It should ignore any hour provided, and should not throw an error even if hour is null.
                 if (flag.equals("r") && isNamePresent) {
                     return new LogCommand(studySpot, null, true, false, false);
+                } else if (flag.equals("o") && isNamePresent) {
+                    isOverride = true;
                 } else if (flag.equals("ra")) {
                     return new LogCommand(studySpot, null, false, false, true);
                 } else {
-                    isOverride = true;
+                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            LogCommand.MESSAGE_INVALID_FLAG));
                 }
             }
-            hoursStudied = ParserUtil.parseStudiedHours(argMultimap.getValue(PREFIX_HOURS).get());
+            hoursStudied =
+                    ParserUtil.parseStudiedHours(argMultimap.getValue(PREFIX_HOURS).orElseThrow(() -> new ParseException(LogCommand.MESSAGE_MISSING_HOURS)));
             return new LogCommand(studySpot, hoursStudied, false, isOverride, false);
         } catch (NoSuchElementException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/LogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LogCommandParser.java
@@ -33,17 +33,13 @@ public class LogCommandParser implements Parser<LogCommand> {
         // log hi hr/3
         if ((!arePrefixesPresent(argMultimap, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) && !args.contains("-r")) {
-            System.out.println("Entering error1");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
         }
 
         // log -r hi (supposed to be log -r n/hi)
         // won't throw error for log -r
-        System.out.println(args);
-        System.out.println(args.equals("-r"));
         if ((!arePrefixesPresent(argMultimap, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) && !args.equals(" -r")) {
-            System.out.println("Entering error2");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/LogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LogCommandParser.java
@@ -46,25 +46,21 @@ public class LogCommandParser implements Parser<LogCommand> {
                 String flag = argMultimap.getValue(PREFIX_FLAG).get();
 
                 if (flag.equals(LogCommand.FLAG_RESET) && isNamePresent) {
-                    return new LogCommand(studySpot, null, true, false,
-                            false);
+                    return new LogCommand(studySpot, null, true, false, false);
                 } else if (flag.equals(LogCommand.FLAG_OVERRIDE) && isNamePresent && isHoursPresent) {
                     isOverride = true;
                 } else if (flag.equals(LogCommand.FLAG_RESET_ALL)) {
-                    return new LogCommand(studySpot, null, false, false,
-                            true);
+                    return new LogCommand(studySpot, null, false, false, true);
                 } else {
                     throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
                 }
             }
 
             if (isHoursPresent) {
-                hoursStudied =
-                        ParserUtil.parseStudiedHours(argMultimap.getValue(PREFIX_HOURS)
-                                .orElseThrow(() -> new ParseException(LogCommand.MESSAGE_MISSING_HOURS)));
+                hoursStudied = ParserUtil.parseStudiedHours(argMultimap.getValue(PREFIX_HOURS).get());
                 return new LogCommand(studySpot, hoursStudied, false, isOverride, false);
             }
-            return new LogCommand(studySpot, null, false, false, false);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
         } catch (NoSuchElementException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.LogCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.amenity.Amenity;
 import seedu.address.model.studyspot.Address;
@@ -121,6 +122,9 @@ public class ParserUtil {
     public static StudiedHours parseStudiedHours(String studiedHours) throws ParseException {
         requireNonNull(studiedHours);
         String trimmedStudiedHours = studiedHours.trim();
+        if (studiedHours.equals("")) {
+            throw new ParseException(LogCommand.MESSAGE_MISSING_HOURS);
+        }
         if (!StudiedHours.isValidLoggedHours(trimmedStudiedHours)) {
             throw new ParseException(StudiedHours.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -240,5 +241,13 @@ public class ParserUtil {
             amenitySet.add(parseAmenity(amenityType));
         }
         return amenitySet;
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UnaliasCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnaliasCommandParser.java
@@ -4,8 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ALIAS_ARGUMENTS;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ALIAS;
-
-import java.util.stream.Stream;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import seedu.address.logic.commands.UnaliasCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -43,13 +42,5 @@ public class UnaliasCommandParser implements Parser<UnaliasCommand> {
         }
 
         return new UnaliasCommand(aliasToRemove);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/LogCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LogCommandParserTest.java
@@ -21,7 +21,8 @@ public class LogCommandParserTest {
         Name name = STARBUCKS.getName();
         StudiedHours studiedHours = new StudiedHours("5");
         String userInput = " " + PREFIX_NAME + name.fullName + " " + PREFIX_HOURS + "5";
-        assertParseSuccess(parser, userInput, new LogCommand(STARBUCKS.getName(), studiedHours, false, false, false));
+        assertParseSuccess(parser, userInput, new LogCommand(STARBUCKS.getName(), studiedHours, false,
+                false, false));
     }
 
     @Test
@@ -36,6 +37,6 @@ public class LogCommandParserTest {
         Name name = STARBUCKS.getName();
         String userInput = " -r " + "-o " + PREFIX_NAME + name.fullName;
         assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                                            LogCommand.MESSAGE_ONE_FLAG));
+                                                            LogCommand.MESSAGE_INVALID_FLAG));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/LogCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LogCommandParserTest.java
@@ -28,7 +28,7 @@ public class LogCommandParserTest {
     @Test
     public void parse_invalidFormat_failure() {
         Name name = STARBUCKS.getName();
-        String userInput = " " +  name.fullName + " " + PREFIX_HOURS + "5";
+        String userInput = " " + name.fullName + " " + PREFIX_HOURS + "5";
         assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/logic/parser/LogCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LogCommandParserTest.java
@@ -28,7 +28,7 @@ public class LogCommandParserTest {
     @Test
     public void parse_invalidFormat_failure() {
         Name name = STARBUCKS.getName();
-        String userInput = " " + PREFIX_NAME + name.fullName + " " + "5";
+        String userInput = " " +  name.fullName + " " + PREFIX_HOURS + "5";
         assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogCommand.MESSAGE_USAGE));
     }
 
@@ -37,6 +37,6 @@ public class LogCommandParserTest {
         Name name = STARBUCKS.getName();
         String userInput = " -r " + "-o " + PREFIX_NAME + name.fullName;
         assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                                            LogCommand.MESSAGE_INVALID_FLAG));
+                                                            LogCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Feels a little brute-forcey not sure if there's a better way to do this 

Resolves #172 #208 

Should we state in the UG that `log -ra` will ignore anything that comes after it? so `log -ra n/starbucks hr/2` will just reset every study spot's hours as usual, and wont throw error message? (This is for #186 )