### PR TITLE
Display relevant error message for tags with spaces

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -197,6 +197,9 @@ public class ParserUtil {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
         if (!Tag.isValidTagName(trimmedTag)) {
+            if (tag.contains(" ")) {
+                throw new ParseException(Tag.MESSAGE_NO_SPACE);
+            }
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
         return new Tag(trimmedTag);

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -10,6 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric, e.g. t/cold.";
+    public static final String MESSAGE_NO_SPACE = "Tags names should not have spaces, e.g. t/veryCrowded.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;


### PR DESCRIPTION
Resolves #170 
Can't seem to change the validation regex in the tag class, it throws some error that can't parse the json files 

If anyone is interested, I think the validation regex for alphanum with spaces is `^[a-zA-Z0-9_ ]*$`  https://stackoverflow.com/questions/15472764/regular-expression-to-allow-spaces-between-words
