### PR TITLE
PED: Fix long tags

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -201,9 +201,12 @@ public class ParserUtil {
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
-        if (!Tag.isValidTagName(trimmedTag)) {
+        if (!Tag.isValidTagName(trimmedTag) || !Tag.isValidTagLength(trimmedTag)) {
             if (tag.contains(" ")) {
                 throw new ParseException(Tag.MESSAGE_NO_SPACE);
+            }
+            if (!Tag.isValidTagLength(trimmedTag)) {
+                throw new ParseException(Tag.MESSAGE_LENGTH);
             }
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -8,8 +8,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
 public class Tag {
+    public static final int TAG_LENGTH = 50;
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric, e.g. t/cold.";
+    public static final String MESSAGE_LENGTH = "Tags must be less than " + TAG_LENGTH + " characters long!";
     public static final String MESSAGE_NO_SPACE = "Tags names should not have spaces, e.g. t/veryCrowded.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
@@ -23,6 +25,7 @@ public class Tag {
     public Tag(String tagName) {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidTagLength(tagName), MESSAGE_LENGTH);
         this.tagName = tagName;
     }
 
@@ -31,6 +34,13 @@ public class Tag {
      */
     public static boolean isValidTagName(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string is a valid tag length.
+     */
+    public static boolean isValidTagLength(String test) {
+        return test.length() < TAG_LENGTH;
     }
 
     @Override

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -20,6 +20,13 @@ public class TagTest {
     }
 
     @Test
+    public void constructor_tooLongTagName_throwsIllegalArgumentException() {
+        String tooLongTagName = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123_"
+                + "ABCDEFGHIJKLMNOPQRSTUVWXYZ123_";
+        assertThrows(IllegalArgumentException.class, () -> new Tag(tooLongTagName));
+    }
+
+    @Test
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));


### PR DESCRIPTION
Long tags don't wrap properly on the GUI, and there is no limit to the tag length

This means the user can theoretically make a really long Tag which doesn't fully display on the GUI.

Let's limit tags to 50 characters.

Fixes #174 