### PR TITLE
Fix inconsistencies in UGDG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -224,7 +224,7 @@ The Alias feature is facilitated by three key classes: `Alias.java`, `StudyTrack
 
 `StudyTrackerParser.java` is responsible for parsing user commands. The key operations needed for Aliases are:
 
-* `StudyTrackerParser#isInvokingAlias()` —  checks if the user input is a normal command, an Alias belonging in `UserPrefs`, or invalid.  
+* `StudyTrackerParser#isInvokingAlias()` —  checks if the user input is a normal command, or one that invokes an Alias belonging in `UserPrefs`.  
 * `StudyTrackerParser#expandAlias()` —  parses the Alias into its corresponding command.
 StudyTrackerParser will prepend the arguments from the expanded command before the arguments in user input, if any.
 
@@ -431,8 +431,8 @@ The following sequence diagram demonstrates how `StudyTrackerParser` parses the 
 #### Design considerations
 
 **Behaviour of filters with multiple tags:**
-* **Current choice:** Filtering by tags show study spots that all specified tags.
-* **Alternative 1:** Filtering by tags show study spots that contain at least one of the specified tags.
+* **Alternative 1 (current choice):** Filtering by tags show study spots that all specified tags.
+* **Alternative 2:** Filtering by tags show study spots that contain at least one of the specified tags.
 
 
 The current choice was chosen as it is intuitive and most modern desktop applications follow this behaviour. 
@@ -463,8 +463,8 @@ The following sequence diagram demonstrates how `StudyTrackerParser` parses the 
 #### Design considerations
 
 **Aspect: How to increase the ease of removing fields in a study spot:**
-- Alternative 1 (current choice): Users can directly remove a tag or an amenity they specify.
-- Alternative 2: Users have to retype existing tags or amenities if they wish to retain them.
+- **Alternative 1 (current choice)**: Users can directly remove a tag or an amenity they specify.
+- **Alternative 2**: Users have to retype existing tags or amenities if they wish to retain them.
 
 ### Themes
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -664,9 +664,11 @@ testers are expected to do more *exploratory* testing.
 
 1. Initial launch
 
-    1. Download the jar file and copy into an empty folder
+    1. Download the jar file and copy into an empty folder.
 
-    1. Double-click the jar file Expected: Shows the GUI with a set of sample contacts. The window size may not be optimum.
+    1. Double-click the jar file.<br>
+       Expected: Shows the GUI with a set of sample study spots.
+       The window size may not be optimum.
 
 1. Saving window preferences
 
@@ -674,8 +676,36 @@ testers are expected to do more *exploratory* testing.
 
     1. Re-launch the app by double-clicking the jar file.<br>
        Expected: The most recent window size and location is retained.
+       
+1. Saving custom themes
 
-1. _{ more test cases …​ }_
+    1. Set a colour theme in the Settings by accessing `File > Settings` in the Menu Bar and selecting a Theme.
+    
+    1. Click on `Save` to apply this theme.<br>
+       Expected: The GUI will change colour to the selected theme. 
+       
+    1. Close the window.
+       
+    1. Re-launch the app by double-clicking the jar file.<br>
+       Expected: The GUI will launch with the selected theme.
+       
+### Adding a study spot
+
+1. Adding a study spot to StudyTracker
+
+    1. Prerequisites: Do not have a study spot named 'Test Spot' already in StudyTracker
+
+    1. Test case: `add n/Test Spot r/5 m/wifi a/Testing`<br>
+       Expected: A study spot named Test Spot, with rating 5, amenity [wifi], address: "Testing" is added to the list.
+       Details of the added study spot is shown in the status message.
+       The study spot is also displayed in the GUI (might require scrolling down the list of study spots).
+       
+    1. Test case: `add n/Test Spot r/3`<br>
+       Expected: No study spot is added as there already exists a study spot named 'Test Spot'.
+       Error details shown in the status message. 
+
+    1. Other incorrect add commands to try: `add New Place`, `add n/New Place`<br>
+       Expected: Error messages for invalid command format is shown.
 
 ### Deleting a study spot
 
@@ -684,15 +714,13 @@ testers are expected to do more *exploratory* testing.
     1. Prerequisites: Have at least 1 study spot in the list. 
 
     1. Test case: `delete n/Central Library`<br>
-       Expected: The study spot named COM1 is deleted from the list. Details of the deleted study spot shown in the status message.
+       Expected: The study spot named Central Library is deleted from the list. Details of the deleted study spot shown in the status message.
 
     1. Test case: `delete n/INVALID`<br>
        Expected: No study spot is deleted as there does not exist a study spot named 'INVALID'. Error details shown in the status message. Similar error message will show if user tries to delete a study spot that does not exist in the list. 
 
     1. Other incorrect delete commands to try: `delete Central Library`, `delete spot/Central Library`<br>
        Expected: Similar to previous.
-       
-1. _{ more test cases …​ }_
 
 ### Adding and using aliases
 
@@ -702,18 +730,21 @@ testers are expected to do more *exploratory* testing.
         1. `myAdd myPlace` 
     
         Expected: A new study spot 'myPlace' with rating 5 is added.
-    Details of this new study spot is shown in the GUI.
+        Details of this new study spot is shown in the GUI. (i.e. the Add command has been executed successfully).
+       
    1. Test case:
         1. `myAdd`
         
-        Expected: No study spot is added.
-      Error details shown in the status message.
+        Expected: No study spot is added. (i.e. the Add command is missing parameters).
+        Error details shown in the status message.
+      
 1. Overwriting an existing alias
    1. Test case:
         1. `alias al/myAdd cmd/list`
         1. `myAdd`
     
-        Expected: All study spots are listed (i.e. the List command has been executed)
+        Expected: All study spots are listed (i.e. the List command has been executed successfully)
+    
 1. Removing an alias
     1. Test case:
         1. `unalias al/myAdd`
@@ -721,12 +752,21 @@ testers are expected to do more *exploratory* testing.
     
         Expected: Unknown command execution.
         Error details  shown in the status message.
-        
+       
+### Logging hours at a study spot
 
-### Saving data
+1. Logging hours studied at a study spot
 
-1. Dealing with missing/corrupted data files
+    1. Prerequisites: Have a study spot named 'Test Spot' already in StudyTracker with 0 hours logged.
+       Refer to Test case *"Adding a study spot"* for steps to achieve this.
 
-    1. _{explain how to simulate a missing/corrupted file, and the expected behavior}_
-
-1. _{ more test cases …​ }_
+    1. Test case: `log n/Test Spot hr/25`<br>
+       Expected:
+       - The study spot named Test Spot will get 25 hours logged to it.
+       - The Hours Studied section of the card will be updated to show "25 hours".
+       - The Hours Studied pie chart will update total hours with 25 additional hours.
+       - The Hours Studied pie chart will have a segment for Test Spot with 25 hours, which shows on mouseover.
+       
+    1. Test case: `add log -ra`<br>
+       Expected: The studied hours are reset from all study spots.
+       The Hours Studied pie chart will not show, and total hours for all study spots are 0.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -19,12 +19,13 @@ Only want to know how to use StudyTracker? Check out the [**User Guide**](UserGu
 
 <div style="page-break-after: always;"></div>
 
-## Table of Contents
+--- 
+## **Table of Contents**
 
 * Table of Contents
 {:toc}
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## **Acknowledgements**
 
@@ -172,7 +173,7 @@ The `Storage` component,
 
 Classes used by multiple components are in the `seedu.address.commons` package.
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## **Implementation**
 
@@ -508,7 +509,8 @@ The following are examples showing the `Default` and `DotsDark` theme.
 * `fg-accent` — contrasting colour to act as accenting colour
 * `fg-text`, `bg-text`, `accent-text` — text colour for `fg-surface`, `bg-surface` and `fg-accent` respectively.
 * `button` — button colour
---------------------------------------------------------------------------------------------------------------------
+
+---
 
 ## **Documentation, logging, testing, configuration, dev-ops**
 
@@ -518,7 +520,7 @@ The following are examples showing the `Default` and `DotsDark` theme.
 * [Configuration guide](Configuration.md)
 * [DevOps guide](DevOps.md)
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## **Appendix: Requirements**
 
@@ -647,7 +649,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 * **Private contact detail**: A contact detail that is not meant to be shared with others
 * **Usable**: All functions can be used even if the user experience is not optimal
 
---------------------------------------------------------------------------------------------------------------------
+---
 
 ## **Appendix: Instructions for manual testing**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -29,7 +29,7 @@ Want to contribute to development? Check out the [**Developer Guide**](Developer
 
 ---
 
-## Table of Contents
+## **Table of Contents**
 
 * Table of Contents
 {:toc}
@@ -38,7 +38,7 @@ Want to contribute to development? Check out the [**Developer Guide**](Developer
 
 <div style="page-break-after: always;"></div>
 
-## Quick Start
+## **Quick Start**
 
 StudyTracker comes with sample data.
 In this **Quick Start** section, we'll go through **a tutorial to try the essential features of StudyTracker.**
@@ -84,7 +84,7 @@ with CLI syntax!
 <div style="page-break-after: always;"></div>
 
 ---
-## How to use this User Guide
+## **How to use this User Guide**
 
 This section provides tips on reading this document, as well as how to navigate it.
 
@@ -188,7 +188,8 @@ Congratulations! 🎉 You should now know how to use CLI. Now all you need to kn
 
 <div style="page-break-after: always;"></div>
 
-## GUI Layout
+---
+## **GUI Layout**
 
 This section introduces the Graphical User Interface (GUI) of StudyTracker.
 
@@ -250,7 +251,8 @@ The **Command Box** is where you can enter [**commands**](#how-to-read-commands-
 Check out <a href="#managing-themes">**Managing Themes**</a> section to change the theme of the GUI!
 </div>
 
-## Features
+---
+## **Features**
 
 This section introduces all the features in StudyTracker.
 
@@ -833,9 +835,9 @@ StudyTracker data are saved as a JSON file `[home folder]/data/studytracker.json
 If your changes to the data file makes its format invalid, StudyTracker will discard all data and start with an empty data file at the next run.
 </div>
 
---------------------------------------------------------------------------------------------------------------------
+---
 
-## FAQ
+## **FAQ**
 
 This section contains frequently asked questions (FAQs) about StudyTracker.
 
@@ -855,9 +857,9 @@ You may also copy the **preferences.json** file to keep your user preferences.
 **Q**: What do I do when I encounter bugs?<br>
 **A**: As much as possible, we rigorously test our application before it is released. However, should you encounter bugs, you can raise issues to our team [here](https://github.com/AY2122S1-CS2103T-T09-1/tp/issues) and we would look to fix them in upcoming patches.
 
---------------------------------------------------------------------------------------------------------------------
+---
 
-## Command summary
+## **Command summary**
 
 Action | Format, Examples
 --------|------------------

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -121,7 +121,7 @@ Commands use a multipart structure that must be specified in this order:
 
 #### Flags
 
-Commands may require **flags**.
+Commands may contain **flags**. All flags are optional.
   Flags are represented by a dash, and a sequence of characters. <br>
   e.g. the `list` command has a `-f` flag to list only favourites.
 
@@ -340,8 +340,7 @@ New study spot added: Starbucks at UTown; Rating: 4; Operating Hours: Weekdays: 
 If you made a mistake in your `add` command, or wish to change the details of a study spot, 
 you can easily do so by making use of the `edit` command!
 
-**Format:** `edit spot/NAME* n/NEW_NAME a/NEW_ADDRESS t/NEW_TAG m/NEW_AMENITY rt/NEW_TAG rm/NEW_AMENITY r/NEW_RATING 
-o/NEW_OPERATING_HOURS`
+**Format:** `edit spot/NAME* n/NEW_NAME a/NEW_ADDRESS t/NEW_TAG m/NEW_AMENITY r/NEW_RATING o/NEW_OPERATING_HOURS rt/OLD_TAG rm/OLD_AMENITY`
 
 * Edits the study spot matching `NAME`.
   The provided `NAME` is not case-sensitive and **must fully match the study spot name**.
@@ -864,7 +863,7 @@ You may also copy the **preferences.json** file to keep your user preferences.
 Action | Format, Examples
 --------|------------------
 **Add** | `add n/NAME* r/RATING* a/ADDRESS t/TAG... m/AMENITY... o/OPERATING_HOURS` <br> e.g. `add n/COM1 r/5`
-**Edit** | `edit spot/NAME* n/NEW_NAME a/NEW_ADDRESS t/NEW_TAG m/NEW_AMENITY rt/NEW_TAG rm/NEW_AMENITY r/NEW_RATING o/NEW_OPERATING_HOURS`<br> e.g.,`edit spot/tr3 n/Training Room 3`
+**Edit** | `edit spot/NAME* n/NEW_NAME a/NEW_ADDRESS t/NEW_TAG m/NEW_AMENITY r/NEW_RATING o/NEW_OPERATING_HOURS rt/OLD_TAG rm/OLD_AMENITY`<br> e.g.,`edit spot/tr3 n/Training Room 3`
 **Favourite**  |  `fav n/NAME*` <br> e.g. `fav n/COM1`
 **Unfavourite** | `unfav n/NAME*` <br> e.g. `unfav n/COM1`
 **Delete** | `delete n/NAME*` <br> e.g. `delete n/COM1`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -413,7 +413,7 @@ Added study spot to favourites: COM1 Tech Hangout
 </tr>
 </table>
 
-<img src="images/add_favourites.png" alt="favourites" height="700"/>
+<img src="images/add_favourites.png" alt="favourites"/>
 
 <div style="page-break-after: always;"></div>
 
@@ -579,7 +579,7 @@ Listed all study spots with Tags: [coffee] with Amenities: [wifi] with Rating: 4
   </tr>
 </table>
 
-<img src="images/list_tags_amenities.png" alt="cold tags" height="700"/>
+<img src="images/list_tags_amenities.png" alt="cold tags"/>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 Make use of command aliases to speed up typing your inputs!


### PR DESCRIPTION
Fixed a couple of inconsistencies in UG/DG:

**Formatting**
- Standardize all h2s to be bolded so it looks nice on the Table of Contents
- Changed horizontal rule to `---` in markdown so it's easier to type
- Standardize image size to not appear squashed
- Made the `Alternative 1`, `Alternative 2`, and `Current choice` consistent for DG Implementation

**Clarity**
- Wrote more Manual Tests in DG, cleaned up that section
- Fixed some inconsistencies in UG (e.g. `rt/NEW_TAG` -> `rt/OLD_TAG`) for remove tag parameter in Edit command)
- Clarified that flags are all optional in `UG -> How to Read Commands -> Flags`. This is because there was some confusion in **Command Summary** in UG where it seems that flags are compulsory.
- Clarified `StudyTrackerParser#isInvokingAlias()` function.

[Preview](https://qreoct.github.io/tp/UserGuide.html)