### PR TITLE
Fix bug with user preferences

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -145,6 +145,9 @@ public class MainApp extends Application {
         UserPrefs initializedPrefs;
         try {
             Optional<UserPrefs> prefsOptional = storage.readUserPrefs();
+            if (prefsOptional.isEmpty()) {
+                logger.info("Preferences file not found. Will be starting with a default preferences file.");
+            }
             initializedPrefs = prefsOptional.orElse(new UserPrefs());
         } catch (DataConversionException e) {
             logger.warning("UserPrefs file at " + prefsFilePath + " is not in the correct format. "

--- a/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
+++ b/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.FileUtil;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
@@ -61,6 +62,7 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
 
     @Override
     public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException {
+        FileUtil.createIfMissing(filePath);
         JsonUtil.saveJsonFile(userPrefs, filePath);
     }
 


### PR DESCRIPTION
Currently, user preferences are not created properly on first launch.

A NoSuchFileException is thrown when trying to create ``preferences.json`

![image](https://user-images.githubusercontent.com/9080974/140754001-36f135f9-9bc6-4184-96c0-e446a0372b00.png)

This happens because Files.write() is attempting to write a file
"data/preferences.json", but since the directory doesn't exist, it
throws a NoSuchFileException.

We have to include in JsonUserPrefsStorage#saveUserPrefs() an additional
call to FileUtil#createIfMissing() in order to create this missing
directory.

With this fix, user preferences should be written properly
to "data/preferences.json" on first launch (when it doesn't exist).